### PR TITLE
Document login debugging steps and surface login confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,49 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Next Profile BG
 
-## Getting Started
+Aplicação base construída com Next.js 15 e autenticação via [NextAuth.js](https://next-auth.js.org/). Este documento reúne o passo a passo para depurar problemas de login (Google OAuth e credenciais) e explica como a confirmação visual de login bem-sucedido foi implementada.
 
-First, run the development server:
+## Visão geral do fluxo de autenticação
+- A configuração dos provedores está centralizada em [`auth.ts`](auth.ts).
+- A tela de login fica em [`app/signin/page.tsx`](app/signin/page.tsx) e envia formulários diretamente para os endpoints padrão do NextAuth.
+- Após autenticação bem-sucedida, o usuário é redirecionado para `/dashboard?login=success`, onde um toast confirma o sucesso do login.
 
+## Debug do login com Google OAuth
+1. **Verifique variáveis de ambiente obrigatórias**
+   - `AUTH_GOOGLE_ID` e `AUTH_GOOGLE_SECRET` devem existir e corresponder às credenciais geradas no [Google Cloud Console](https://console.cloud.google.com/).
+   - `NEXTAUTH_URL` deve apontar para a URL pública (ou `http://localhost:3000` em desenvolvimento) para que o fluxo OAuth finalize corretamente.
+2. **Confirme URIs autorizadas no Google**
+   - A URI de redirecionamento deve incluir `https://<host>/api/auth/callback/google` e, em desenvolvimento, `http://localhost:3000/api/auth/callback/google`.
+3. **Cheque a configuração do provedor**
+   - Abra [`auth.ts`](auth.ts) e confirme que o provider Google está sendo registrado com os valores esperados.
+4. **Habilite logs detalhados**
+   - Execute o app com `NEXTAUTH_DEBUG=true npm run dev` para imprimir no terminal o passo a passo do fluxo e erros retornados pelo Google.
+5. **Inspecione a requisição no navegador**
+   - No DevTools, acompanhe a chamada `POST /api/auth/signin/google` gerada pela tela de login e verifique se há erros de CORS, cookies bloqueados ou status HTTP inesperados.
+6. **Verifique o relógio do servidor**
+   - Grandes divergências de horário podem invalidar tokens OAuth. Garanta que a máquina está sincronizada (ex.: `timedatectl status`).
+
+## Debug do login com credenciais (email/senha)
+1. **Banco de dados acessível**
+   - `DATABASE_URL` precisa apontar para um banco acessível. Rode `npx prisma migrate status` ou `npx prisma studio` para confirmar conectividade.
+2. **Usuário com hash armazenado**
+   - Verifique na tabela `User` se o campo `passwordHash` está preenchido. Caso contrário, crie/atualize o usuário usando a mesma rotina de hash utilizada em [`prisma/seed.ts`](prisma/seed.ts) ou pela API de signup.
+3. **Logs do NextAuth**
+   - Ative `NEXTAUTH_DEBUG=true` para exibir no terminal mensagens de erro lançadas durante `authorize` em [`auth.ts`](auth.ts).
+4. **Conferência manual da senha**
+   - Utilize um script Node para validar `bcrypt.compare` entre a senha digitada e o hash salvo, descartando problemas de encoding ou espaçamento.
+5. **Inspecione os envios da tela de login**
+   - Na aba Network do DevTools, confira o `POST /api/auth/callback/credentials`: o corpo deve conter `email` e `password`, e a resposta deve ser `302` em caso de sucesso.
+6. **Audite middlewares ou policies**
+   - Caso haja middlewares ou edge functions customizadas (não presentes por padrão), confirme que elas não estão barrando a requisição.
+
+## Confirmação visual de login bem-sucedido
+1. A tela de login envia `callbackUrl=/dashboard?login=success` (veja [`app/signin/page.tsx`](app/signin/page.tsx)).
+2. A página protegida inclui o componente [`LoginSuccessToast`](components/login-success-toast.tsx), que lê o parâmetro `login=success`, dispara um toast com o `sonner` e remove o parâmetro da URL usando `router.replace`.
+3. O toaster global já está registrado em [`app/layout.tsx`](app/layout.tsx); portanto, nenhum ajuste adicional é necessário para que a notificação apareça.
+
+## Como executar o projeto localmente
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+A aplicação estará disponível em `http://localhost:3000`.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/auth";
 import { redirect } from "next/navigation";
+import { LoginSuccessToast } from "@/components/login-success-toast";
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
@@ -9,6 +10,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="mx-auto max-w-5xl p-6">
+      <LoginSuccessToast />
       <h1 className="text-2xl font-bold">
         Olá, {session.user.name ?? session.user.email}
       </h1>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -25,6 +25,7 @@ export default async function SignInPage() {
           {/* OAuth (endpoints automáticos) */}
           {hasGoogleOAuth ? (
             <form action="/api/auth/signin/google" method="post">
+              <input type="hidden" name="callbackUrl" value="/dashboard?login=success" />
               <Button type="submit" className="w-full">
                 Entrar com Google
               </Button>
@@ -43,6 +44,7 @@ export default async function SignInPage() {
               method="post"
               className="space-y-2"
             >
+              <input type="hidden" name="callbackUrl" value="/dashboard?login=success" />
               <input
                 name="email"
                 type="email"

--- a/components/login-success-toast.tsx
+++ b/components/login-success-toast.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+export function LoginSuccessToast() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [shown, setShown] = useState(false);
+
+  const loginStatus = searchParams.get("login");
+
+  useEffect(() => {
+    if (shown) return;
+    if (loginStatus !== "success") return;
+
+    toast.success("Login realizado com sucesso!");
+    setShown(true);
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("login");
+    const query = params.toString();
+
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [loginStatus, pathname, router, searchParams, shown]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- document detailed troubleshooting steps for Google OAuth and credentials login flows in the README
- attach a callbackUrl to the Google and credentials forms so successful logins redirect with a success flag
- render a client toast component on the dashboard to confirm the login and clear the query parameter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dffedc3e9083338878398d8a90c4ab