### PR TITLE
Fix authentication validation and improve post-login UX

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,32 @@
 import type { Metadata } from "next";
+import { getServerSession } from "next-auth";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { AuthProvider } from "@/components/auth-provider";
+import { authOptions } from "@/auth";
 
 export const metadata: Metadata = {
   title: "Next Profile BG",
   description: "App base com Next.js + shadcn/ui + lucide-react",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getServerSession(authOptions);
+
   return (
     <html lang="pt-BR" suppressHydrationWarning>
       <body className="min-h-dvh bg-background text-foreground antialiased">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          {children}
-          <Toaster richColors position="top-right" />
-        </ThemeProvider>
+        <AuthProvider session={session}>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            {children}
+            <Toaster richColors position="top-right" />
+          </ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,15 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { User, Image as ImageIcon, Brush } from "lucide-react";
+
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { User, Image as ImageIcon, Brush } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { LoginSuccessToast } from "@/components/login-success-toast";
 import { prisma } from "@/lib/db";
+import { authOptions } from "@/auth";
 
 async function getDemoUser() {
   if (!process.env.DATABASE_URL || !prisma) {
@@ -31,6 +37,8 @@ async function getDemoUser() {
 }
 
 export default async function Home() {
+  const session = await getServerSession(authOptions);
+  const loggedInUser = session?.user ?? null;
   const { user, activeBg, totalBgs } = await getDemoUser();
 
   return (
@@ -38,6 +46,7 @@ export default async function Home() {
       <SiteHeader />
       <section className="flex-1">
         <div className="mx-auto max-w-5xl px-4 py-10">
+          <LoginSuccessToast />
           <div className="mb-8 text-center">
             <h1 className="text-3xl font-bold tracking-tight">Next Profile BG</h1>
             <p className="text-muted-foreground mt-2">
@@ -47,11 +56,46 @@ export default async function Home() {
 
           <div className="grid md:grid-cols-2 gap-6">
             <Card>
-              <CardHeader><CardTitle>Usuário Demo</CardTitle></CardHeader>
-              <CardContent className="space-y-2">
-                <p><strong>Email:</strong> {user?.email ?? "—"}</p>
-                <p><strong>Nome:</strong> {user?.name ?? "—"}</p>
-                <p><strong>Backgrounds salvos:</strong> {totalBgs}</p>
+              <CardHeader>
+                <CardTitle>{loggedInUser ? "Sua conta" : "Usuário Demo"}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {loggedInUser ? (
+                  <div className="flex items-center gap-4">
+                    <Avatar className="size-16">
+                      {loggedInUser.image ? (
+                        <AvatarImage
+                          src={loggedInUser.image}
+                          alt={loggedInUser.name ?? loggedInUser.email ?? "Usuário"}
+                        />
+                      ) : (
+                        <AvatarFallback className="text-lg">
+                          {(loggedInUser.name || loggedInUser.email || "?")
+                            .slice(0, 2)
+                            .toUpperCase()}
+                        </AvatarFallback>
+                      )}
+                    </Avatar>
+                    <div>
+                      <p className="font-semibold text-lg">{loggedInUser.name ?? loggedInUser.email}</p>
+                      {loggedInUser.email && loggedInUser.name && (
+                        <p className="text-sm text-muted-foreground">{loggedInUser.email}</p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p>
+                      <strong>Email:</strong> {user?.email ?? "—"}
+                    </p>
+                    <p>
+                      <strong>Nome:</strong> {user?.name ?? "—"}
+                    </p>
+                    <p>
+                      <strong>Backgrounds salvos:</strong> {totalBgs}
+                    </p>
+                  </>
+                )}
               </CardContent>
             </Card>
 
@@ -68,7 +112,12 @@ export default async function Home() {
                   <p className="text-muted-foreground">Nenhum background ativo.</p>
                 )}
                 <div className="flex gap-2 flex-wrap">
-                  <Button variant="default"><User className="mr-2 h-4 w-4" /> Login</Button>
+                  <Button variant="default" asChild>
+                    <Link href={loggedInUser ? "/dashboard" : "/signin"}>
+                      <User className="mr-2 h-4 w-4" />
+                      {loggedInUser ? "Minha conta" : "Login"}
+                    </Link>
+                  </Button>
                   <Button variant="secondary"><ImageIcon className="mr-2 h-4 w-4" /> Trocar Foto de Perfil</Button>
                   <Button variant="outline"><Brush className="mr-2 h-4 w-4" /> Alterar Background</Button>
                 </div>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -25,7 +25,7 @@ export default async function SignInPage() {
           {/* OAuth (endpoints automáticos) */}
           {hasGoogleOAuth ? (
             <form action="/api/auth/signin/google" method="post">
-              <input type="hidden" name="callbackUrl" value="/dashboard?login=success" />
+              <input type="hidden" name="callbackUrl" value="/?login=success" />
               <Button type="submit" className="w-full">
                 Entrar com Google
               </Button>
@@ -44,7 +44,7 @@ export default async function SignInPage() {
               method="post"
               className="space-y-2"
             >
-              <input type="hidden" name="callbackUrl" value="/dashboard?login=success" />
+              <input type="hidden" name="callbackUrl" value="/?login=success" />
               <input
                 name="email"
                 type="email"

--- a/auth.ts
+++ b/auth.ts
@@ -6,12 +6,20 @@ import bcrypt from "bcrypt";
 
 import { prisma } from "@/lib/db";
 
-const providers: NextAuthOptions["providers"] = [
-  Google({
-    clientId: process.env.AUTH_GOOGLE_ID ?? "",
-    clientSecret: process.env.AUTH_GOOGLE_SECRET ?? "",
-  }),
-];
+const providers: NextAuthOptions["providers"] = [];
+
+const hasGoogleOAuth = Boolean(
+  process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET,
+);
+
+if (hasGoogleOAuth) {
+  providers.push(
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID!,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET!,
+    }),
+  );
+}
 
 if (prisma) {
   providers.push(

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { Session } from "next-auth";
+import { SessionProvider } from "next-auth/react";
+
+export function AuthProvider({
+  children,
+  session,
+}: {
+  children: ReactNode;
+  session?: Session | null;
+}) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}

--- a/components/login-success-toast.tsx
+++ b/components/login-success-toast.tsx
@@ -16,7 +16,7 @@ export function LoginSuccessToast() {
     if (shown) return;
     if (loginStatus !== "success") return;
 
-    toast.success("Login realizado com sucesso!");
+    toast.success("Login realizado com sucesso");
     setShown(true);
 
     const params = new URLSearchParams(searchParams.toString());

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,31 +1,65 @@
 "use client";
 
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { LogIn, LogOut, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 export function SiteHeader() {
+  const { data: session } = useSession();
+  const user = session?.user ?? null;
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  const initials = useMemo(() => {
+    if (!user) return "";
+    const source = user.name || user.email || "";
+    return source.slice(0, 2).toUpperCase();
+  }, [user]);
+
   return (
     <header className="w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="font-semibold text-lg">next-profile-bg</Link>
-        <nav className="flex items-center gap-2">
-          <Link href="/signin">
-            <Button variant="ghost" size="icon" title="Login">
-              <LogIn className="h-5 w-5" />
+        <Link href="/" className="font-semibold text-lg">
+          next-profile-bg
+        </Link>
+        <nav className="flex items-center gap-3">
+          {user ? (
+            <>
+              <div className="flex items-center gap-3 rounded-full border px-3 py-1.5">
+                <Avatar className="size-9">
+                  {user.image ? (
+                    <AvatarImage src={user.image} alt={user.name ?? user.email ?? "Usuário"} />
+                  ) : (
+                    <AvatarFallback>{initials || <LogIn className="h-4 w-4" />}</AvatarFallback>
+                  )}
+                </Avatar>
+                <div className="leading-tight">
+                  <p className="text-sm font-medium">{user.name ?? user.email}</p>
+                  {user.email && user.name && (
+                    <p className="text-xs text-muted-foreground">{user.email}</p>
+                  )}
+                </div>
+              </div>
+              <form action="/api/auth/signout" method="post">
+                <Button variant="ghost" size="icon" title="Sair">
+                  <LogOut className="h-5 w-5" />
+                </Button>
+              </form>
+            </>
+          ) : (
+            <Button asChild variant="ghost" title="Entrar" className="px-3">
+              <Link href="/signin">
+                <LogIn className="h-5 w-5" />
+                Entrar
+              </Link>
             </Button>
-          </Link>
-          <form action="/api/auth/signout" method="post">
-            <Button variant="ghost" size="icon" title="Logout">
-              <LogOut className="h-5 w-5" />
-            </Button>
-          </form>
+          )}
           <Button
             variant="outline"
             size="icon"


### PR DESCRIPTION
## Summary
- ensure OAuth and credentials providers are only enabled when properly configured and keep credential validation tied to Prisma
- redirect both authentication flows back to the home page, surface the login success toast, and show the signed-in user details
- expose session data through a top-level provider so the header can render the current user with avatar and sign-out controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e00530e96c8333834d9e3553d7bad7