### PR TITLE
Add local storage fallback for uploads

### DIFF
--- a/app/api/profile/photo/route.ts
+++ b/app/api/profile/photo/route.ts
@@ -2,10 +2,8 @@ import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { uploadBuffer } from "@/lib/dropbox";
+import { storeProfileImage } from "@/lib/storage";
 import { assertImage, sanitizeExt } from "@/lib/file";
-
-const appName = process.env.APP_NAME ?? "next-profile-bg";
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -31,10 +29,8 @@ export async function POST(request: Request) {
   const ext = sanitizeExt(file.type);
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
-  const dropboxPath = `/apps/${appName}/profiles/${session.user.id}.${ext}`;
-
   try {
-    const imageUrl = await uploadBuffer(dropboxPath, buffer, "overwrite");
+    const imageUrl = await storeProfileImage(session.user.id, ext, buffer);
 
     const updated = await prisma.user.update({
       where: { id: Number(session.user.id) },

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -12,15 +12,24 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 export function SiteHeader() {
   const { data: session } = useSession();
   const user = session?.user ?? null;
+  const rawName = user?.name?.trim();
+  const displayName = rawName && rawName.length > 0 ? rawName : "Usuário";
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
   const initials = useMemo(() => {
-    if (!user) return "";
-    const source = user.name || user.email || "";
-    return source.slice(0, 2).toUpperCase();
-  }, [user]);
+    const source = rawName;
+    if (!source) return "";
+    const parts = source.split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "";
+    if (parts.length === 1) {
+      return parts[0]!.slice(0, 2).toUpperCase();
+    }
+    const first = parts[0]?.[0] ?? "";
+    const last = parts.at(-1)?.[0] ?? "";
+    return `${first}${last}`.toUpperCase();
+  }, [rawName]);
 
   return (
     <header className="w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -34,16 +43,13 @@ export function SiteHeader() {
               <div className="flex items-center gap-3 rounded-full border px-3 py-1.5">
                 <Avatar className="size-9">
                   {user.image ? (
-                    <AvatarImage src={user.image} alt={user.name ?? user.email ?? "Usuário"} />
+                    <AvatarImage src={user.image} alt={displayName} />
                   ) : (
                     <AvatarFallback>{initials || <LogIn className="h-4 w-4" />}</AvatarFallback>
                   )}
                 </Avatar>
                 <div className="leading-tight">
-                  <p className="text-sm font-medium">{user.name ?? user.email}</p>
-                  {user.email && user.name && (
-                    <p className="text-xs text-muted-foreground">{user.email}</p>
-                  )}
+                  <p className="text-sm font-medium">{displayName}</p>
                 </div>
               </div>
               <form action="/api/auth/signout" method="post">

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,2 @@
+export { prisma } from "./prisma";
+export type { PrismaClient } from "@prisma/client";

--- a/lib/dropbox.ts
+++ b/lib/dropbox.ts
@@ -37,7 +37,10 @@ async function ensureSharedLink(client: Dropbox, path: string) {
   return created.result.url;
 }
 
-export async function uploadBuffer(path: string, buffer: Buffer, mode: files.WriteModeOption = "overwrite") {
+type WriteModeTag = Exclude<files.WriteMode[".tag"], "update">;
+type WriteModeInput = files.WriteMode | WriteModeTag;
+
+export async function uploadBuffer(path: string, buffer: Buffer, mode: WriteModeInput = "overwrite") {
   const client = getDropbox();
   const writeMode: files.WriteMode =
     typeof mode === "string" ? { ".tag": mode } : mode;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const appName = process.env.APP_NAME ?? "next-profile-bg";
+
+async function tryDropboxUpload(dropboxPath: string, buffer: Buffer) {
+  if (!process.env.DROPBOX_ACCESS_TOKEN) {
+    return null;
+  }
+
+  try {
+    const dropbox = await import("./dropbox");
+    return await dropbox.uploadBuffer(dropboxPath, buffer, "overwrite");
+  } catch (error) {
+    console.error("Falha ao enviar arquivo ao Dropbox", error);
+    return null;
+  }
+}
+
+async function ensureDir(dirSegments: string[]) {
+  const dirPath = path.join(process.cwd(), "public", ...dirSegments);
+  await fs.mkdir(dirPath, { recursive: true });
+  return dirPath;
+}
+
+async function removeByPrefix(dirPath: string, prefix: string) {
+  try {
+    const entries = await fs.readdir(dirPath);
+    await Promise.all(
+      entries
+        .filter((entry) => entry.startsWith(prefix))
+        .map((entry) => fs.rm(path.join(dirPath, entry)).catch(() => undefined)),
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      console.error("Falha ao remover arquivos antigos", error);
+    }
+  }
+}
+
+async function saveLocalFile(dirSegments: string[], fileName: string, buffer: Buffer) {
+  const dirPath = await ensureDir(dirSegments);
+  await fs.writeFile(path.join(dirPath, fileName), buffer);
+  const urlPath = ["", ...dirSegments, fileName]
+    .map((segment) => segment.replace(/\\/g, "/"))
+    .join("/");
+  return `${urlPath}?v=${Date.now()}`;
+}
+
+function sanitizeSegment(value: string) {
+  const cleaned = value.replace(/[^a-zA-Z0-9_-]/g, "");
+  return cleaned.length > 0 ? cleaned : "item";
+}
+
+export async function storeProfileImage(userId: string, ext: string, buffer: Buffer) {
+  const dropboxPath = `/apps/${appName}/profiles/${userId}.${ext}`;
+  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer);
+  if (dropboxUrl) {
+    return dropboxUrl;
+  }
+
+  const dir = ["uploads", "profiles"];
+  const safeId = sanitizeSegment(userId);
+  const fileName = `${safeId}-${Date.now()}.${ext}`;
+  const dirPath = path.join(process.cwd(), "public", ...dir);
+  await removeByPrefix(dirPath, `${safeId}-`);
+  return saveLocalFile(dir, fileName, buffer);
+}
+
+export async function storeBackgroundImage(ext: string, buffer: Buffer) {
+  const dropboxPath = `/apps/${appName}/backgrounds/current.${ext}`;
+  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer);
+  if (dropboxUrl) {
+    return dropboxUrl;
+  }
+
+  const dir = ["uploads", "backgrounds"];
+  const fileName = `background-${Date.now()}.${ext}`;
+  const dirPath = path.join(process.cwd(), "public", ...dir);
+  await removeByPrefix(dirPath, "background-");
+  return saveLocalFile(dir, fileName, buffer);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 
 import { auth } from "@/lib/auth";
 
 const protectedMatchers = ["/dashboard", "/api/profile"];
 
-export async function middleware(request: NextRequest) {
+export default auth((request) => {
   const { pathname } = request.nextUrl;
   const requiresAuth = protectedMatchers.some((path) => pathname === path || pathname.startsWith(`${path}/`));
 
@@ -13,15 +12,14 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const session = await auth(request);
-  if (session?.user?.id) {
+  if (request.auth?.user?.id) {
     return NextResponse.next();
   }
 
   const redirectUrl = new URL("/login", request.url);
   redirectUrl.searchParams.set("callbackUrl", request.nextUrl.pathname + request.nextUrl.search);
   return NextResponse.redirect(redirectUrl);
-}
+});
 
 export const config = {
   matcher: ["/dashboard/:path*", "/api/profile/:path*"],


### PR DESCRIPTION
## Summary
- add a storage helper that falls back to local files when Dropbox is unavailable and use it for profile/background uploads
- clean up the site header to avoid relying on a missing email property and expose a prisma alias via lib/db
- update Dropbox typings and middleware auth usage to satisfy strict TypeScript checks

## Testing
- npm run lint
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e022ea29788333adb986aa277d1bfd