### PR TITLE
feat: add upload logging panel to home page

### DIFF
--- a/components/ChangePhoto.tsx
+++ b/components/ChangePhoto.tsx
@@ -1,7 +1,88 @@
 "use client";
 
-import { FormEvent, useState, useTransition } from "react";
+import { FormEvent, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+
+import type { UploadLogEntry, UploadLogLevel } from "@/types/upload";
+
+type UploadAttemptStatus = "pending" | "success" | "error";
+
+interface UploadAttempt {
+  id: string;
+  filename: string | null;
+  startedAt: string;
+  status: UploadAttemptStatus;
+  logs: UploadLogEntry[];
+}
+
+function createClientLog(level: UploadLogLevel, message: string): UploadLogEntry {
+  return {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function normalizeServerLogs(value: unknown): UploadLogEntry[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const allowedLevels: UploadLogLevel[] = ["info", "success", "warning", "error"];
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+
+      const entry = item as Partial<UploadLogEntry>;
+      if (
+        typeof entry.message !== "string" ||
+        typeof entry.level !== "string" ||
+        typeof entry.timestamp !== "string"
+      ) {
+        return null;
+      }
+
+      if (!allowedLevels.includes(entry.level as UploadLogLevel)) {
+        return null;
+      }
+
+      return {
+        message: entry.message,
+        level: entry.level as UploadLogLevel,
+        timestamp: entry.timestamp,
+      } satisfies UploadLogEntry;
+    })
+    .filter((entry): entry is UploadLogEntry => Boolean(entry));
+}
+
+function formatTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+const statusLabels: Record<UploadAttemptStatus, { label: string; className: string }> = {
+  pending: { label: "Em andamento", className: "text-amber-600" },
+  success: { label: "Concluído", className: "text-green-600" },
+  error: { label: "Com falha", className: "text-red-600" },
+};
+
+const levelClasses: Record<UploadLogLevel, string> = {
+  info: "text-slate-700",
+  success: "text-green-700",
+  warning: "text-amber-700",
+  error: "text-red-700",
+};
 
 export function ChangePhoto() {
   const router = useRouter();
@@ -9,6 +90,7 @@ export function ChangePhoto() {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [attempts, setAttempts] = useState<UploadAttempt[]>([]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     const form = event.currentTarget;
@@ -24,6 +106,35 @@ export function ChangePhoto() {
     const formData = new FormData();
     formData.append("file", file);
 
+    const attemptId = typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random()}`;
+    const initialAttempt: UploadAttempt = {
+      id: attemptId,
+      filename: file.name ?? null,
+      startedAt: new Date().toISOString(),
+      status: "pending",
+      logs: [createClientLog("info", "Iniciando envio da foto de perfil...")],
+    };
+
+    setAttempts((previous) => [initialAttempt, ...previous]);
+
+    const appendToAttempt = (newLogs: UploadLogEntry[], status?: UploadAttemptStatus) => {
+      setAttempts((previous) =>
+        previous.map((attempt) =>
+          attempt.id === attemptId
+            ? {
+                ...attempt,
+                status: status ?? attempt.status,
+                logs: [...attempt.logs, ...newLogs],
+              }
+            : attempt,
+        ),
+      );
+    };
+
+    appendToAttempt([createClientLog("info", "Enviando arquivo para o servidor...")]);
+
     startTransition(async () => {
       try {
         const response = await fetch("/api/profile/photo", {
@@ -32,47 +143,129 @@ export function ChangePhoto() {
         });
 
         const data = await response.json();
+        const serverLogs = normalizeServerLogs(data.logs);
+
         if (!response.ok) {
-          setError(data.error ?? "Erro ao enviar foto");
+          appendToAttempt(
+            [
+              ...serverLogs,
+              createClientLog("error", data.error ?? "Erro ao enviar foto."),
+            ],
+            "error",
+          );
+          setError(data.error ?? "Erro ao enviar foto.");
           return;
         }
+
+        appendToAttempt(
+          [
+            ...serverLogs,
+            createClientLog("success", "Upload concluído sem erros."),
+          ],
+          "success",
+        );
 
         setMessage("Foto atualizada com sucesso!");
         setFile(null);
         form.reset();
         router.refresh();
       } catch (err) {
-        setError("Erro inesperado ao enviar foto.");
         console.error(err);
+        appendToAttempt(
+          [createClientLog("error", "Erro inesperado ao enviar foto.")],
+          "error",
+        );
+        setError("Erro inesperado ao enviar foto.");
       }
     });
   };
 
+  const sortedAttempts = useMemo(
+    () =>
+      [...attempts].sort((a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+      ),
+    [attempts],
+  );
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-3 border rounded-lg p-4 bg-white/80 shadow">
-      <div>
-        <label className="block text-sm font-medium mb-1" htmlFor="profile-photo">
-          Nova foto de perfil
-        </label>
-        <input
-          id="profile-photo"
-          name="file"
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-          className="block w-full text-sm"
-        />
-        <p className="text-xs text-slate-600 mt-1">JPEG, PNG ou WebP até 2MB.</p>
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-3 border rounded-lg p-4 bg-white/80 shadow">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="profile-photo">
+            Nova foto de perfil
+          </label>
+          <input
+            id="profile-photo"
+            name="file"
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+            className="block w-full text-sm"
+          />
+          <p className="text-xs text-slate-600 mt-1">JPEG, PNG ou WebP até 2MB.</p>
+        </div>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {isPending ? "Enviando..." : "Trocar Foto de Perfil"}
+        </button>
+        {message && <p className="text-sm text-green-600">{message}</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+
+      <UploadLogPanel attempts={sortedAttempts} />
+    </div>
+  );
+}
+
+function UploadLogPanel({ attempts }: { attempts: UploadAttempt[] }) {
+  if (attempts.length === 0) {
+    return (
+      <div className="border rounded-lg bg-white/80 p-4 shadow">
+        <h3 className="text-lg font-semibold">Painel de logs de upload</h3>
+        <p className="mt-2 text-sm text-slate-600">
+          Os detalhes de cada envio aparecerão aqui assim que você enviar uma foto.
+        </p>
       </div>
-      <button
-        type="submit"
-        disabled={isPending}
-        className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-      >
-        {isPending ? "Enviando..." : "Trocar Foto de Perfil"}
-      </button>
-      {message && <p className="text-sm text-green-600">{message}</p>}
-      {error && <p className="text-sm text-red-600">{error}</p>}
-    </form>
+    );
+  }
+
+  return (
+    <div className="border rounded-lg bg-white/80 p-4 shadow">
+      <h3 className="text-lg font-semibold">Painel de logs de upload</h3>
+      <div className="mt-4 space-y-4">
+        {attempts.map((attempt) => {
+          const status = statusLabels[attempt.status];
+          const formattedDate = formatTime(attempt.startedAt);
+
+          return (
+            <div key={attempt.id} className="rounded-md border bg-white/70 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                <div className="font-medium text-slate-800">
+                  {attempt.filename ?? "Envio de foto"}
+                </div>
+                <div className={`text-xs font-semibold ${status.className}`}>
+                  {status.label}
+                </div>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">Iniciado às {formattedDate}.</p>
+              <ul className="mt-3 space-y-1">
+                {attempt.logs.map((log, index) => (
+                  <li key={`${attempt.id}-${index}`} className="flex gap-3 text-xs">
+                    <span className="font-mono text-[0.65rem] text-slate-500">
+                      {formatTime(log.timestamp)}
+                    </span>
+                    <span className={`${levelClasses[log.level]} flex-1`}>{log.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,18 +1,69 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { UploadLogEntry } from "@/types/upload";
+
 const appName = process.env.APP_NAME ?? "next-profile-bg";
 
-async function tryDropboxUpload(dropboxPath: string, buffer: Buffer) {
+function createLog(level: UploadLogEntry["level"], message: string): UploadLogEntry {
+  return {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+interface DropboxUploadOptions {
+  logs?: UploadLogEntry[];
+  itemDescription?: string;
+  successMessage?: string;
+  skipMessage?: string;
+}
+
+async function tryDropboxUpload(
+  dropboxPath: string,
+  buffer: Buffer,
+  { logs, itemDescription = "arquivo", successMessage, skipMessage }: DropboxUploadOptions = {},
+) {
+  const description = itemDescription;
+
   if (!process.env.DROPBOX_ACCESS_TOKEN) {
+    logs?.push(
+      createLog(
+        "warning",
+        skipMessage ?? "Token do Dropbox não configurado. O arquivo será salvo localmente.",
+      ),
+    );
     return null;
   }
 
+  logs?.push(createLog("info", `Enviando ${description} para o Dropbox...`));
+
   try {
     const dropbox = await import("./dropbox");
-    return await dropbox.uploadBuffer(dropboxPath, buffer, "overwrite");
+    const url = await dropbox.uploadBuffer(dropboxPath, buffer, "overwrite");
+    if (url) {
+      logs?.push(
+        createLog("success", successMessage ?? "Upload concluído no Dropbox."),
+      );
+    } else {
+      logs?.push(
+        createLog(
+          "warning",
+          `Dropbox não retornou uma URL válida para o ${description}. Prosseguindo com armazenamento local.`,
+        ),
+      );
+    }
+    return url;
   } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro desconhecido";
     console.error("Falha ao enviar arquivo ao Dropbox", error);
+    logs?.push(
+      createLog(
+        "error",
+        `Falha ao enviar ${description} para o Dropbox: ${message}. Prosseguindo com armazenamento local.`,
+      ),
+    );
     return null;
   }
 }
@@ -53,23 +104,43 @@ function sanitizeSegment(value: string) {
 }
 
 export async function storeProfileImage(userId: string, ext: string, buffer: Buffer) {
+  const logs: UploadLogEntry[] = [];
+
   const dropboxPath = `/apps/${appName}/profiles/${userId}.${ext}`;
-  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer);
+  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer, {
+    logs,
+    itemDescription: "foto de perfil",
+    successMessage: "Upload da foto concluído no Dropbox.",
+    skipMessage: "Token do Dropbox não configurado. Salvando foto de perfil localmente.",
+  });
+
   if (dropboxUrl) {
-    return dropboxUrl;
+    return { imageUrl: dropboxUrl, logs };
   }
+
+  logs.push(createLog("info", "Preparando armazenamento local para a foto de perfil..."));
 
   const dir = ["uploads", "profiles"];
   const safeId = sanitizeSegment(userId);
   const fileName = `${safeId}-${Date.now()}.${ext}`;
   const dirPath = path.join(process.cwd(), "public", ...dir);
+
   await removeByPrefix(dirPath, `${safeId}-`);
-  return saveLocalFile(dir, fileName, buffer);
+  logs.push(createLog("info", "Fotos antigas removidas do armazenamento local."));
+
+  const imageUrl = await saveLocalFile(dir, fileName, buffer);
+  logs.push(createLog("success", "Foto salva com sucesso no armazenamento local."));
+
+  return { imageUrl, logs };
 }
 
 export async function storeBackgroundImage(ext: string, buffer: Buffer) {
   const dropboxPath = `/apps/${appName}/backgrounds/current.${ext}`;
-  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer);
+  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer, {
+    itemDescription: "background",
+    successMessage: "Upload do background concluído no Dropbox.",
+    skipMessage: "Token do Dropbox não configurado. Salvando background localmente.",
+  });
   if (dropboxUrl) {
     return dropboxUrl;
   }

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -1,0 +1,7 @@
+export type UploadLogLevel = "info" | "success" | "warning" | "error";
+
+export interface UploadLogEntry {
+  message: string;
+  level: UploadLogLevel;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- add structured upload logs to profile photo storage and API responses
- update the profile photo form to collect and display detailed attempt history
- introduce shared upload log types for consistent typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0283bf004833385ef4bc295acf63e