### PR TITLE
Restrict background customization to logged in users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,7 +93,7 @@ export default async function HomePage() {
             </div>
 
             {session?.user && <ChangePhoto />}
-            <ChangeBackground />
+            {session?.user && <ChangeBackground isAuthenticated />}
             <DropboxConnectionTest />
           </div>
         </section>

--- a/components/ChangeBackground.tsx
+++ b/components/ChangeBackground.tsx
@@ -5,14 +5,22 @@ import { useRouter } from "next/navigation";
 
 type Mode = "url" | "upload";
 
-export function ChangeBackground() {
+export function ChangeBackground({
+  isAuthenticated,
+}: {
+  isAuthenticated: boolean;
+}) {
   const router = useRouter();
   const [mode, setMode] = useState<Mode>("url");
-  const [url, setUrl] = useState("");
+  const [url, setUrl] = useState<string>("");
   const [file, setFile] = useState<File | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  if (!isAuthenticated) {
+    return null;
+  }
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -90,7 +98,7 @@ export function ChangeBackground() {
               id="background-url"
               type="url"
               value={url}
-              onChange={(event) => setUrl(event.target.value)}
+              onChange={(event) => setUrl(event.currentTarget.value)}
               placeholder="https://exemplo.com/imagem.jpg"
               className="w-full rounded-md border px-3 py-2 text-sm"
               required


### PR DESCRIPTION
## Summary
- hide the background customization form unless a session is present
- normalize the background URL input handler to keep the field controlled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11c629608833385b624d6b9ca7420