### PR TITLE
Fix background change mode toggle to keep URL input controlled

### DIFF
--- a/components/ChangeBackground.tsx
+++ b/components/ChangeBackground.tsx
@@ -12,7 +12,7 @@ export function ChangeBackground({
 }) {
   const router = useRouter();
   const [mode, setMode] = useState<Mode>("url");
-  const [url, setUrl] = useState<string>("");
+  const [url, setUrl] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,19 +69,31 @@ export function ChangeBackground({
     });
   };
 
+  const handleModeChange = (newMode: Mode) => {
+    setMode(newMode);
+    setMessage(null);
+    setError(null);
+
+    if (newMode === "url") {
+      setFile(null);
+    } else {
+      setUrl("");
+    }
+  };
+
   return (
     <div className="border rounded-lg p-4 space-y-3 bg-white/80 shadow">
       <div className="flex gap-2">
         <button
           type="button"
-          onClick={() => setMode("url")}
+          onClick={() => handleModeChange("url")}
           className={`flex-1 rounded-md px-3 py-2 text-sm font-medium ${mode === "url" ? "bg-blue-600 text-white" : "bg-slate-200"}`}
         >
           Usar URL
         </button>
         <button
           type="button"
-          onClick={() => setMode("upload")}
+          onClick={() => handleModeChange("upload")}
           className={`flex-1 rounded-md px-3 py-2 text-sm font-medium ${mode === "upload" ? "bg-blue-600 text-white" : "bg-slate-200"}`}
         >
           Enviar arquivo
@@ -98,7 +110,7 @@ export function ChangeBackground({
               id="background-url"
               type="url"
               value={url}
-              onChange={(event) => setUrl(event.currentTarget.value)}
+              onChange={(event) => setUrl(event.currentTarget.value || "")}
               placeholder="https://exemplo.com/imagem.jpg"
               className="w-full rounded-md border px-3 py-2 text-sm"
               required


### PR DESCRIPTION
## Summary
- keep the background URL field fully controlled by resetting state when switching modes
- clear any previous error or success messages whenever the user toggles between URL and upload modes
- reset the opposite input (file or URL) when switching modes to avoid stale values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11db505fc8333a9bd4ff88cfad1dc