### PR TITLE
Fix controlled/uncontrolled background input

### DIFF
--- a/components/ChangeBackground.tsx
+++ b/components/ChangeBackground.tsx
@@ -107,6 +107,7 @@ export function ChangeBackground({
               URL do background (https)
             </label>
             <input
+              key="url-input"
               id="background-url"
               type="url"
               value={url}
@@ -122,6 +123,7 @@ export function ChangeBackground({
               Arquivo do background
             </label>
             <input
+              key="file-input"
               id="background-file"
               type="file"
               accept="image/jpeg,image/png,image/webp"


### PR DESCRIPTION
## Summary
- add unique keys to the URL and file inputs in the background changer
- prevent React from reusing the same input instance when switching modes, avoiding the controlled/uncontrolled warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11f1fb7948333addf37c8ddc31a79