### PR TITLE
Add fixed animated navbar with auth-aware controls

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+
+import { Navbar } from "@/components/navbar";
+import { auth } from "@/lib/auth";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -6,10 +10,19 @@ export const metadata: Metadata = {
   description: "Gerencie foto de perfil e background com Next.js",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+
   return (
     <html lang="pt-BR">
-      <body>{children}</body>
+      <body className="font-sans antialiased">
+        <Navbar user={session?.user ?? null} />
+        <div className="pt-20 lg:pt-24">{children}</div>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,10 @@
 import Link from "next/link";
 
-import { auth, signOut } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { ChangePhoto } from "@/components/ChangePhoto";
 import { ChangeBackground } from "@/components/ChangeBackground";
 import { DropboxConnectionTest } from "@/components/DropboxConnectionTest";
-
-async function logout() {
-  "use server";
-  await signOut({ redirectTo: "/" });
-}
 
 export default async function HomePage() {
   const session = await auth();
@@ -39,31 +34,6 @@ export default async function HomePage() {
       }
     >
       <div className="min-h-dvh bg-white/70 flex flex-col">
-        <header className="w-full border-b bg-white/80 backdrop-blur-sm">
-          <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-4 py-4">
-            <h1 className="text-xl font-semibold">next-profile-bg</h1>
-            <nav className="flex items-center gap-3 text-sm">
-              {session?.user ? (
-                <form action={logout}>
-                  <button
-                    type="submit"
-                    className="rounded-md border px-3 py-2 font-medium hover:bg-slate-100"
-                  >
-                    Sair
-                  </button>
-                </form>
-              ) : (
-                <Link
-                  href="/login"
-                  className="rounded-md border px-3 py-2 font-medium hover:bg-slate-100"
-                >
-                  Login
-                </Link>
-              )}
-            </nav>
-          </div>
-        </header>
-
         <section className="flex-1">
           <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10">
             <div className="rounded-lg bg-white/80 p-6 shadow">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,0 +1,139 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import {
+  Home,
+  Info,
+  LayoutDashboard,
+  LogIn,
+  LogOut,
+  MapPin,
+  User,
+} from "lucide-react";
+
+import type { Session } from "next-auth";
+
+import { signOut } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+
+interface NavbarProps {
+  user: Session["user"] | null;
+}
+
+async function handleSignOut() {
+  "use server";
+
+  await signOut({ redirectTo: "/" });
+}
+
+export function Navbar({ user }: NavbarProps) {
+  const isAuthenticated = Boolean(user);
+
+  const primaryLinks = [
+    {
+      href: "/",
+      label: "Home",
+      icon: Home,
+    },
+    {
+      href: "#destinos",
+      label: "Destinos",
+      icon: MapPin,
+    },
+    {
+      href: "#sobre-nos",
+      label: "Sobre nós",
+      icon: Info,
+    },
+  ];
+
+  const authenticatedLinks = [
+    {
+      href: "#usuario",
+      label: "Usuário",
+      icon: User,
+    },
+    {
+      href: "/dashboard",
+      label: "Painel Admin",
+      icon: LayoutDashboard,
+    },
+  ];
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-5 py-4 sm:flex-nowrap sm:gap-6">
+        <Link href="/" className="group flex items-center gap-3">
+          <span className="relative inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-primary/20 bg-primary/10 text-primary transition-transform duration-200 group-hover:-translate-y-0.5">
+            <Image
+              src="/globe.svg"
+              alt="Logo da empresa"
+              width={32}
+              height={32}
+              className="size-6 text-primary"
+            />
+          </span>
+          <span className="text-lg font-semibold tracking-tight transition-colors duration-200 group-hover:text-primary">
+            Next Profile BG
+          </span>
+        </Link>
+
+        <nav className="flex flex-1 flex-wrap items-center justify-end gap-2 text-sm font-medium md:gap-4">
+          <div className="flex items-center gap-2">
+            {primaryLinks.map(({ href, label, icon: Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className="group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+              >
+                <Icon className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                {label}
+              </Link>
+            ))}
+          </div>
+
+          {isAuthenticated && (
+            <div className="flex items-center gap-2">
+              {authenticatedLinks.map(({ href, label, icon: Icon }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+                >
+                  <Icon className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                  {label}
+                </Link>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            {!isAuthenticated && (
+              <Link
+                href="/login"
+                className="group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+              >
+                <LogIn className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                Login
+              </Link>
+            )}
+            {isAuthenticated && (
+              <form action={handleSignOut}>
+                <button
+                  type="submit"
+                  className={cn(
+                    "group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-destructive/30 hover:bg-destructive/10 text-destructive",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-destructive/60",
+                  )}
+                >
+                  <LogOut className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                  Sair
+                </button>
+              </form>
+            )}
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a fixed, translucent navbar with Lucide icons, animation, and auth-aware buttons
- integrate the navbar into the root layout so all pages share it and remove the redundant header from the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e121dfee988333adbbac1c2e6ee25f