### PR TITLE
Add dedicated user and admin pages with profile tools

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
+import { ChangeBackground } from "@/components/ChangeBackground";
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -9,12 +11,41 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
+  let backgroundUrl: string | null = null;
+
+  try {
+    const settings = await prisma.globalSetting.findUnique({
+      where: { id: 1 },
+      select: { backgroundUrl: true },
+    });
+
+    backgroundUrl = settings?.backgroundUrl ?? null;
+  } catch {
+    backgroundUrl = null;
+  }
+
   return (
-    <div className="mx-auto max-w-3xl px-4 py-10 space-y-3">
-      <h1 className="text-2xl font-semibold">Dashboard</h1>
-      <p className="text-slate-600">
-        Olá, <strong>{session.user.name ?? "usuário"}</strong>. Esta rota está protegida pelo middleware.
-      </p>
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10">
+      <div className="rounded-lg bg-white/80 p-6 shadow space-y-3">
+        <h1 className="text-2xl font-semibold">Painel admin</h1>
+        <p className="text-slate-600">
+          Olá, <strong>{session.user.name ?? "usuário"}</strong>. Utilize esta página para gerenciar o background global do site.
+        </p>
+        {backgroundUrl && (
+          <div className="space-y-2">
+            <p className="text-sm text-slate-500">Background atual:</p>
+            <div className="overflow-hidden rounded-lg border">
+              <div
+                className="h-40 w-full bg-cover bg-center"
+                style={{ backgroundImage: `url(${backgroundUrl})` }}
+              />
+            </div>
+            <code className="block truncate rounded-md bg-slate-100 px-3 py-2 text-xs text-slate-600">{backgroundUrl}</code>
+          </div>
+        )}
+      </div>
+
+      <ChangeBackground isAuthenticated />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,6 @@ import Link from "next/link";
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { ChangePhoto } from "@/components/ChangePhoto";
-import { ChangeBackground } from "@/components/ChangeBackground";
 import { DropboxConnectionTest } from "@/components/DropboxConnectionTest";
 
 export default async function HomePage() {
@@ -39,10 +37,10 @@ export default async function HomePage() {
             <div className="rounded-lg bg-white/80 p-6 shadow">
               <h2 className="text-2xl font-semibold">Bem-vindo!</h2>
               <p className="mt-2 text-sm text-slate-600">
-                Configure sua foto de perfil e o background global. Faça login para alterar sua foto.
+                Gerencie sua identidade visual no Next Profile BG alterando a foto de perfil e o background global.
               </p>
               {session?.user ? (
-                <div className="mt-4 space-y-2">
+                <div className="mt-4 space-y-4">
                   <p className="text-sm text-slate-700">
                     Usuário logado: <strong>{session.user.name ?? "Usuário"}</strong>
                   </p>
@@ -54,6 +52,20 @@ export default async function HomePage() {
                       className="h-20 w-20 rounded-full border object-cover"
                     />
                   )}
+                  <div className="flex flex-wrap gap-3">
+                    <Link
+                      href="/usuario"
+                      className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
+                    >
+                      Acessar página do usuário
+                    </Link>
+                    <Link
+                      href="/dashboard"
+                      className="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50"
+                    >
+                      Ir para o painel admin
+                    </Link>
+                  </div>
                 </div>
               ) : (
                 <p className="mt-4 text-sm text-slate-700">
@@ -62,8 +74,6 @@ export default async function HomePage() {
               )}
             </div>
 
-            {session?.user && <ChangePhoto />}
-            {session?.user && <ChangeBackground isAuthenticated />}
             <DropboxConnectionTest />
           </div>
         </section>

--- a/app/usuario/page.tsx
+++ b/app/usuario/page.tsx
@@ -1,0 +1,55 @@
+import Image from "next/image";
+import { redirect } from "next/navigation";
+
+import { ChangePhoto } from "@/components/ChangePhoto";
+import { auth } from "@/lib/auth";
+
+export default async function UsuarioPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const { user } = session;
+  const displayName = user.name?.trim() ? user.name : "Usuário";
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10">
+      <div className="rounded-lg bg-white/80 p-6 shadow">
+        <h1 className="text-2xl font-semibold">Perfil do usuário</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Atualize sua foto de perfil para personalizar sua experiência em toda a
+          plataforma.
+        </p>
+        <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center">
+          {user.image ? (
+            <Image
+              src={user.image}
+              alt={`Foto de ${displayName}`}
+              width={96}
+              height={96}
+              className="h-24 w-24 rounded-full border object-cover"
+            />
+          ) : (
+            <div className="flex h-24 w-24 items-center justify-center rounded-full border bg-slate-100 text-xl font-semibold text-slate-500">
+              {displayName.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <div className="space-y-1 text-sm text-slate-700">
+            <p>
+              <strong>Nome:</strong> {displayName}
+            </p>
+            {user.email && (
+              <p>
+                <strong>E-mail:</strong> {user.email}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ChangePhoto />
+    </div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -47,18 +47,14 @@ export function Navbar({ user }: NavbarProps) {
     },
   ];
 
-  const authenticatedLinks = [
-    {
-      href: "#usuario",
-      label: "Usuário",
-      icon: User,
-    },
-    {
-      href: "/dashboard",
-      label: "Painel Admin",
-      icon: LayoutDashboard,
-    },
-  ];
+  const userDisplayName = user?.name?.trim() ? user.name : "Usuário";
+
+  const adminLink = {
+    href: "/dashboard",
+    label: "Painel Admin",
+    icon: LayoutDashboard,
+  } as const;
+  const AdminIcon = adminLink.icon;
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -94,16 +90,29 @@ export function Navbar({ user }: NavbarProps) {
 
           {isAuthenticated && (
             <div className="flex items-center gap-2">
-              {authenticatedLinks.map(({ href, label, icon: Icon }) => (
-                <Link
-                  key={href}
-                  href={href}
-                  className="group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
-                >
-                  <Icon className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
-                  {label}
-                </Link>
-              ))}
+              <Link
+                href="/usuario"
+                className="group flex items-center gap-2 rounded-full border border-transparent px-3 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+              >
+                {user?.image ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={user.image}
+                    alt={userDisplayName}
+                    className="h-8 w-8 rounded-full border object-cover transition-transform duration-200 group-hover:scale-105"
+                  />
+                ) : (
+                  <User className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                )}
+                <span className="font-medium">{userDisplayName}</span>
+              </Link>
+              <Link
+                href={adminLink.href}
+                className="group flex items-center gap-2 rounded-full border border-transparent px-4 py-2 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+              >
+                <AdminIcon className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                {adminLink.label}
+              </Link>
             </div>
           )}
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
 
-const protectedMatchers = ["/dashboard", "/api/profile"];
+const protectedMatchers = ["/dashboard", "/api/profile", "/usuario"];
 
 export default auth((request) => {
   const { pathname } = request.nextUrl;
@@ -22,5 +22,5 @@ export default auth((request) => {
 });
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/api/profile/:path*"],
+  matcher: ["/dashboard/:path*", "/api/profile/:path*", "/usuario/:path*"],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a protected /usuario page that shows account details and exposes the profile photo update flow
- enhance the admin dashboard with current background information and the background update form
- refresh navigation, home messaging, middleware, and image settings to surface the logged-in user identity and new routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1251cf4488333a8ab0a64f25e6485