### PR TITLE
Add destinations catalog screens and data model

### DIFF
--- a/app/destinos/page.tsx
+++ b/app/destinos/page.tsx
@@ -1,0 +1,145 @@
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+import { CreateDestinationForm } from "@/components/destinations/create-destination-form";
+import { DestinationGrid } from "@/components/destinations/destination-grid";
+import {
+  DestinationFormState,
+  destinationFormSchema,
+  serializeDestination,
+  type SerializedDestination,
+} from "@/lib/destinations";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+async function createDestination(
+  _prevState: DestinationFormState,
+  formData: FormData
+): Promise<DestinationFormState> {
+  "use server";
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return {
+      status: "error",
+      message: "Você precisa estar autenticado para criar um destino.",
+    };
+  }
+
+  const photosRaw = String(formData.get("photos") ?? "");
+  const photos = photosRaw
+    .split(/\r?\n|,/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const parsed = destinationFormSchema.safeParse({
+    name: formData.get("name"),
+    city: formData.get("city"),
+    description: formData.get("description"),
+    price: formData.get("price"),
+    peopleCount: formData.get("peopleCount"),
+    startDate: formData.get("startDate"),
+    endDate: formData.get("endDate"),
+    rating: formData.get("rating"),
+    photos,
+  });
+
+  if (!parsed.success) {
+    const errors = parsed.error.flatten().fieldErrors;
+    return {
+      status: "error",
+      message: "Revise os campos destacados antes de salvar.",
+      errors,
+    };
+  }
+
+  try {
+    await prisma.destination.create({
+      data: {
+        name: parsed.data.name,
+        city: parsed.data.city,
+        description: parsed.data.description,
+        price: new Prisma.Decimal(parsed.data.price),
+        peopleCount: parsed.data.peopleCount,
+        startDate: parsed.data.startDate,
+        endDate: parsed.data.endDate,
+        rating: parsed.data.rating,
+        photos: parsed.data.photos,
+        userId: Number(session.user.id),
+      },
+    });
+  } catch (error) {
+    console.error("Erro ao criar destino", error);
+    return {
+      status: "error",
+      message: "Não foi possível criar o destino. Tente novamente mais tarde.",
+    };
+  }
+
+  revalidatePath("/destinos");
+  revalidatePath("/");
+
+  return {
+    status: "success",
+    message: "Destino criado com sucesso!",
+  };
+}
+
+export default async function DestinationsPage() {
+  const session = await auth();
+
+  let destinations: SerializedDestination[] = [];
+  let destinationsError = false;
+  try {
+    const destinationsFromDb = await prisma.destination.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+    destinations = destinationsFromDb.map(serializeDestination);
+  } catch (error) {
+    console.error("Erro ao buscar destinos", error);
+    destinationsError = true;
+  }
+
+  return (
+    <main className="bg-slate-100">
+      <section className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10">
+        <header className="space-y-3">
+          <p className="text-sm font-medium uppercase tracking-wide text-primary">
+            Destinos exclusivos
+          </p>
+          <h1 className="text-3xl font-semibold text-slate-900">
+            Explore e cadastre experiências inesquecíveis
+          </h1>
+          <p className="max-w-2xl text-sm text-slate-600">
+            Descubra os melhores roteiros para seus clientes e mantenha o catálogo sempre atualizado com novos destinos, fotos e informações completas.
+          </p>
+        </header>
+
+        {session?.user ? (
+          <CreateDestinationForm action={createDestination} />
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-300 bg-white/80 p-6 text-sm text-slate-600">
+            Faça login para cadastrar novos destinos e gerenciar o catálogo da agência.
+          </div>
+        )}
+
+        <div className="space-y-4" id="destinos">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-semibold text-slate-900">Destinos cadastrados</h2>
+            <span className="text-sm text-slate-500">
+              {destinations.length} destino(s) disponível(is)
+            </span>
+          </div>
+
+          {destinationsError ? (
+            <p className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+              Não foi possível carregar os destinos no momento. Tente novamente mais tarde.
+            </p>
+          ) : (
+            <DestinationGrid destinations={destinations} />
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,13 @@
 import Link from "next/link";
 
-import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
 import { DropboxConnectionTest } from "@/components/DropboxConnectionTest";
+import { DestinationGrid } from "@/components/destinations/destination-grid";
+import { auth } from "@/lib/auth";
+import {
+  serializeDestination,
+  type SerializedDestination,
+} from "@/lib/destinations";
+import { prisma } from "@/lib/prisma";
 
 export default async function HomePage() {
   const session = await auth();
@@ -16,6 +21,16 @@ export default async function HomePage() {
     backgroundUrl = settings?.backgroundUrl ?? null;
   } catch {
     backgroundUrl = null;
+  }
+
+  let destinations: SerializedDestination[] = [];
+  try {
+    const destinationsFromDb = await prisma.destination.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+    destinations = destinationsFromDb.map(serializeDestination);
+  } catch {
+    destinations = [];
   }
 
   return (
@@ -73,6 +88,31 @@ export default async function HomePage() {
                 </p>
               )}
             </div>
+
+            <section
+              id="destinos"
+              className="rounded-lg bg-white/80 p-6 shadow"
+            >
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                  <div>
+                    <h3 className="text-xl font-semibold text-slate-900">
+                      Destinos disponíveis
+                    </h3>
+                    <p className="text-sm text-slate-600">
+                      Confira as últimas experiências cadastradas e inspire-se para a próxima viagem.
+                    </p>
+                  </div>
+                  <Link
+                    href="/destinos"
+                    className="text-sm font-medium text-blue-600 hover:text-blue-700"
+                  >
+                    Ver todos os destinos
+                  </Link>
+                </div>
+                <DestinationGrid destinations={destinations} />
+              </div>
+            </section>
 
             <DropboxConnectionTest />
           </div>

--- a/components/destinations/create-destination-form.tsx
+++ b/components/destinations/create-destination-form.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFormState } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  DestinationFormState,
+  destinationFormInitialState,
+} from "@/lib/destinations";
+
+interface CreateDestinationFormProps {
+  action: (
+    state: DestinationFormState,
+    formData: FormData
+  ) => Promise<DestinationFormState>;
+}
+
+export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [state, formAction] = useFormState(action, destinationFormInitialState);
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset();
+    }
+  }, [state.status]);
+
+  const getError = (field: string) => state.errors?.[field] ?? [];
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
+    >
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold text-slate-900">
+          Cadastre um novo destino
+        </h2>
+        <p className="text-sm text-slate-600">
+          Preencha todos os campos para disponibilizar um novo destino aos seus clientes.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="name" className="text-sm font-medium text-slate-700">
+            Nome do destino
+          </label>
+          <Input
+            id="name"
+            name="name"
+            placeholder="Ex.: Praia dos Sonhos"
+            aria-invalid={getError("name").length > 0}
+            required
+          />
+          {getError("name").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="city" className="text-sm font-medium text-slate-700">
+            Cidade do destino
+          </label>
+          <Input
+            id="city"
+            name="city"
+            placeholder="Ex.: Fortaleza - CE"
+            aria-invalid={getError("city").length > 0}
+            required
+          />
+          {getError("city").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="price" className="text-sm font-medium text-slate-700">
+            Valor por pessoa (R$)
+          </label>
+          <Input
+            id="price"
+            name="price"
+            type="number"
+            step="0.01"
+            min="0"
+            placeholder="Ex.: 1999.90"
+            aria-invalid={getError("price").length > 0}
+            required
+          />
+          {getError("price").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="peopleCount"
+            className="text-sm font-medium text-slate-700"
+          >
+            Quantidade de pessoas
+          </label>
+          <Input
+            id="peopleCount"
+            name="peopleCount"
+            type="number"
+            min="1"
+            step="1"
+            placeholder="Ex.: 4"
+            aria-invalid={getError("peopleCount").length > 0}
+            required
+          />
+          {getError("peopleCount").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="startDate" className="text-sm font-medium text-slate-700">
+            Data de ida
+          </label>
+          <Input
+            id="startDate"
+            name="startDate"
+            type="date"
+            aria-invalid={getError("startDate").length > 0}
+            required
+          />
+          {getError("startDate").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="endDate" className="text-sm font-medium text-slate-700">
+            Data de volta
+          </label>
+          <Input
+            id="endDate"
+            name="endDate"
+            type="date"
+            aria-invalid={getError("endDate").length > 0}
+            required
+          />
+          {getError("endDate").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="rating" className="text-sm font-medium text-slate-700">
+            Nota do destino (0 a 5)
+          </label>
+          <Input
+            id="rating"
+            name="rating"
+            type="number"
+            min="0"
+            max="5"
+            step="0.1"
+            placeholder="Ex.: 4.8"
+            aria-invalid={getError("rating").length > 0}
+            required
+          />
+          {getError("rating").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="md:col-span-2 space-y-2">
+          <label
+            htmlFor="description"
+            className="text-sm font-medium text-slate-700"
+          >
+            Descrição completa
+          </label>
+          <Textarea
+            id="description"
+            name="description"
+            placeholder="Conte todos os diferenciais, experiências e detalhes deste destino."
+            aria-invalid={getError("description").length > 0}
+            required
+          />
+          {getError("description").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="md:col-span-2 space-y-2">
+          <label htmlFor="photos" className="text-sm font-medium text-slate-700">
+            URLs das fotos (uma por linha)
+          </label>
+          <Textarea
+            id="photos"
+            name="photos"
+            placeholder={"https://exemplo.com/foto-1.jpg\nhttps://exemplo.com/foto-2.jpg"}
+            aria-invalid={getError("photos").length > 0}
+            required
+          />
+          {getError("photos").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+      </div>
+
+      {state.message && (
+        <div
+          className={
+            state.status === "success"
+              ? "rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+              : "rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+          }
+          role="status"
+        >
+          {state.message}
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button type="submit" className="min-w-[160px]">
+          Salvar destino
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/destinations/destination-card.tsx
+++ b/components/destinations/destination-card.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import Image from "next/image";
+import { useMemo, useState } from "react";
+
+import {
+  CalendarRange,
+  ChevronLeft,
+  ChevronRight,
+  MapPin,
+  Star,
+  Users,
+} from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import type { SerializedDestination } from "@/lib/destinations";
+import { cn } from "@/lib/utils";
+
+interface DestinationCardProps {
+  destination: SerializedDestination;
+}
+
+export function DestinationCard({ destination }: DestinationCardProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const photos = destination.photos.length > 0 ? destination.photos : ["/placeholder.jpg"];
+
+  const priceFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("pt-BR", {
+        style: "currency",
+        currency: "BRL",
+      }),
+    []
+  );
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("pt-BR", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+      }),
+    []
+  );
+
+  const handlePrevious = () => {
+    setActiveIndex((current) =>
+      current === 0 ? photos.length - 1 : Math.max(current - 1, 0)
+    );
+  };
+
+  const handleNext = () => {
+    setActiveIndex((current) => (current + 1) % photos.length);
+  };
+
+  const formattedPrice = priceFormatter.format(destination.price);
+  const formattedStartDate = dateFormatter.format(new Date(destination.startDate));
+  const formattedEndDate = dateFormatter.format(new Date(destination.endDate));
+
+  const stayLabel = `${formattedStartDate} - ${formattedEndDate}`;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Card className="h-full cursor-pointer transition-transform duration-200 hover:-translate-y-1 hover:shadow-md">
+          <CardHeader className="gap-4">
+            <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-muted">
+              <Image
+                src={photos[activeIndex]}
+                alt={destination.name}
+                fill
+                className="object-cover"
+                sizes="(min-width: 1280px) 380px, (min-width: 768px) 320px, 100vw"
+                priority={false}
+              />
+              {photos.length > 1 && (
+                <>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      handlePrevious();
+                    }}
+                    className="absolute left-2 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition hover:bg-black/70"
+                    aria-label="Foto anterior"
+                  >
+                    <ChevronLeft className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      handleNext();
+                    }}
+                    className="absolute right-2 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition hover:bg-black/70"
+                    aria-label="Próxima foto"
+                  >
+                    <ChevronRight className="size-4" />
+                  </button>
+                </>
+              )}
+              {photos.length > 1 && (
+                <div className="absolute inset-x-0 bottom-2 flex justify-center gap-1">
+                  {photos.map((photo, index) => (
+                    <span
+                      key={photo + index}
+                      className={cn(
+                        "h-2 w-2 rounded-full bg-white/50",
+                        index === activeIndex && "bg-white"
+                      )}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="space-y-1">
+              <CardTitle className="text-lg font-semibold text-slate-900">
+                {destination.name}
+              </CardTitle>
+              <CardDescription className="flex items-center gap-2 text-sm text-slate-600">
+                <MapPin className="size-4 text-primary" />
+                {destination.city}
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-base font-semibold text-slate-900">
+                {formattedPrice}
+              </span>
+              <div className="flex items-center gap-1 text-sm text-amber-500">
+                <Star className="size-4" />
+                <span>{destination.rating.toFixed(1)}</span>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+              <span className="inline-flex items-center gap-2">
+                <CalendarRange className="size-4 text-primary" />
+                {stayLabel}
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <Users className="size-4 text-primary" />
+                {destination.peopleCount} pessoas
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl space-y-6">
+        <DialogHeader className="space-y-2">
+          <DialogTitle className="text-2xl font-semibold text-slate-900">
+            {destination.name}
+          </DialogTitle>
+          <DialogDescription className="flex items-center gap-2 text-base text-slate-600">
+            <MapPin className="size-4 text-primary" />
+            {destination.city}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-3 rounded-lg bg-slate-100 p-4 text-sm text-slate-700">
+            <p className="flex items-center gap-2 text-base font-medium text-slate-900">
+              <CalendarRange className="size-4 text-primary" />
+              {stayLabel}
+            </p>
+            <p className="flex items-center gap-2">
+              <Users className="size-4 text-primary" />
+              Acomoda até {destination.peopleCount} pessoa(s)
+            </p>
+            <p className="flex items-center gap-2">
+              <Star className="size-4 text-amber-500" />
+              Nota média: {destination.rating.toFixed(1)}
+            </p>
+            <p>
+              <span className="font-medium text-slate-900">Investimento:</span> {formattedPrice}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <h4 className="text-base font-semibold text-slate-900">Descrição</h4>
+            <p className="text-sm leading-relaxed text-slate-700">
+              {destination.description}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <h4 className="text-base font-semibold text-slate-900">Galeria de fotos</h4>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {photos.map((photo, index) => (
+              <div
+                key={`${photo}-${index}`}
+                className="relative aspect-video overflow-hidden rounded-lg border"
+              >
+                <Image
+                  src={photo}
+                  alt={`${destination.name} - foto ${index + 1}`}
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1280px) 480px, (min-width: 768px) 380px, 100vw"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className={cn(buttonVariants({ variant: "outline" }), "min-w-[140px]")}
+            onClick={() => {
+              const url = `https://www.google.com/maps/search/${encodeURIComponent(
+                destination.city
+              )}`;
+              window.open(url, "_blank");
+            }}
+          >
+            Ver no mapa
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/destinations/destination-grid.tsx
+++ b/components/destinations/destination-grid.tsx
@@ -1,0 +1,25 @@
+import type { SerializedDestination } from "@/lib/destinations";
+
+import { DestinationCard } from "./destination-card";
+
+interface DestinationGridProps {
+  destinations: SerializedDestination[];
+}
+
+export function DestinationGrid({ destinations }: DestinationGridProps) {
+  if (destinations.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-600">
+        Ainda não há destinos cadastrados. Assim que você adicionar um destino, ele aparecerá aqui.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+      {destinations.map((destination) => (
+        <DestinationCard key={destination.id} destination={destination} />
+      ))}
+    </div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,7 +36,7 @@ export function Navbar({ user }: NavbarProps) {
       icon: Home,
     },
     {
-      href: "#destinos",
+      href: "/destinos",
       label: "Destinos",
       icon: MapPin,
     },

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[120px] w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/lib/destinations.ts
+++ b/lib/destinations.ts
@@ -1,0 +1,84 @@
+import type { Destination } from "@prisma/client";
+import { z } from "zod";
+
+export const destinationFormSchema = z
+  .object({
+    name: z.string().min(1, "O nome do destino é obrigatório.").trim(),
+    city: z.string().min(1, "A cidade do destino é obrigatória.").trim(),
+    description: z
+      .string()
+      .min(1, "A descrição do destino é obrigatória.")
+      .trim(),
+    price: z
+      .coerce
+      .number({ invalid_type_error: "Informe um valor válido." })
+      .min(0, "O valor deve ser maior ou igual a 0."),
+    peopleCount: z
+      .coerce
+      .number({ invalid_type_error: "Informe a quantidade de pessoas." })
+      .int("A quantidade de pessoas deve ser um número inteiro.")
+      .min(1, "A quantidade mínima é 1."),
+    startDate: z.coerce.date({ invalid_type_error: "Data de ida inválida." }),
+    endDate: z.coerce.date({ invalid_type_error: "Data de volta inválida." }),
+    rating: z
+      .coerce
+      .number({ invalid_type_error: "Informe uma nota válida." })
+      .min(0, "A nota mínima é 0.")
+      .max(5, "A nota máxima é 5."),
+    photos: z
+      .array(z.string().url("Informe URLs válidas para as fotos."))
+      .min(1, "Informe pelo menos uma foto."),
+  })
+  .refine(
+    (data) => data.endDate >= data.startDate,
+    {
+      path: ["endDate"],
+      message: "A data de volta deve ser posterior ou igual à data de ida.",
+    }
+  );
+
+export type DestinationFormInput = z.infer<typeof destinationFormSchema>;
+
+export type DestinationFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  errors?: Record<string, string[]>;
+};
+
+export const destinationFormInitialState: DestinationFormState = {
+  status: "idle",
+};
+
+export type SerializedDestination = {
+  id: number;
+  name: string;
+  city: string;
+  description: string;
+  price: number;
+  peopleCount: number;
+  startDate: string;
+  endDate: string;
+  rating: number;
+  photos: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function serializeDestination(
+  destination: Destination
+): SerializedDestination {
+  return {
+    id: destination.id,
+    name: destination.name,
+    city: destination.city,
+    description: destination.description,
+    price: Number(destination.price),
+    peopleCount: destination.peopleCount,
+    startDate: destination.startDate.toISOString(),
+    endDate: destination.endDate.toISOString(),
+    rating: destination.rating,
+    photos: destination.photos,
+    createdAt: destination.createdAt.toISOString(),
+    updatedAt: destination.updatedAt.toISOString(),
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,9 +14,28 @@ model User {
   imageUrl     String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  destinations Destination[]
 }
 
 model GlobalSetting {
   id            Int    @id
   backgroundUrl String?
+}
+
+model Destination {
+  id           Int       @id @default(autoincrement())
+  name         String
+  city         String
+  description  String
+  price        Decimal
+  peopleCount  Int
+  startDate    DateTime
+  endDate      DateTime
+  rating       Float
+  photos       String[]
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId Int
 }


### PR DESCRIPTION
## Summary
- define the `Destination` model in Prisma and relate it to users
- add a dedicated destinations page with server actions to create new entries and resilient loading
- show reusable destination cards on both the home page and the new listing, including modal details and creation form UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12964a2088333876f9b45113c2ed3