### PR TITLE
Implement destination management features

### DIFF
--- a/components/destinations/create-destination-form.tsx
+++ b/components/destinations/create-destination-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useFormState } from "react-dom";
+import { useActionState, useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,7 +19,10 @@ interface CreateDestinationFormProps {
 
 export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
-  const [state, formAction] = useFormState(action, destinationFormInitialState);
+  const [state, formAction, isPending] = useActionState(
+    action,
+    destinationFormInitialState
+  );
 
   useEffect(() => {
     if (state.status === "success") {
@@ -239,8 +241,8 @@ export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
       )}
 
       <div className="flex justify-end">
-        <Button type="submit" className="min-w-[160px]">
-          Salvar destino
+        <Button type="submit" className="min-w-[160px]" disabled={isPending}>
+          {isPending ? "Salvando..." : "Salvar destino"}
         </Button>
       </div>
     </form>

--- a/components/destinations/destination-grid.tsx
+++ b/components/destinations/destination-grid.tsx
@@ -1,12 +1,17 @@
-import type { SerializedDestination } from "@/lib/destinations";
+import type {
+  DestinationDeleteAction,
+  SerializedDestination,
+} from "@/lib/destinations";
 
 import { DestinationCard } from "./destination-card";
+import { ManageableDestinationCard } from "./manageable-destination-card";
 
 interface DestinationGridProps {
   destinations: SerializedDestination[];
+  onDelete?: DestinationDeleteAction;
 }
 
-export function DestinationGrid({ destinations }: DestinationGridProps) {
+export function DestinationGrid({ destinations, onDelete }: DestinationGridProps) {
   if (destinations.length === 0) {
     return (
       <p className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-600">
@@ -17,9 +22,17 @@ export function DestinationGrid({ destinations }: DestinationGridProps) {
 
   return (
     <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-      {destinations.map((destination) => (
-        <DestinationCard key={destination.id} destination={destination} />
-      ))}
+      {destinations.map((destination) =>
+        onDelete ? (
+          <ManageableDestinationCard
+            key={destination.id}
+            destination={destination}
+            action={onDelete}
+          />
+        ) : (
+          <DestinationCard key={destination.id} destination={destination} />
+        )
+      )}
     </div>
   );
 }

--- a/components/destinations/manageable-destination-card.tsx
+++ b/components/destinations/manageable-destination-card.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  destinationDeleteInitialState,
+  type DestinationDeleteAction,
+  type SerializedDestination,
+} from "@/lib/destinations";
+import { cn } from "@/lib/utils";
+
+import { DestinationCard } from "./destination-card";
+
+interface ManageableDestinationCardProps {
+  destination: SerializedDestination;
+  action: DestinationDeleteAction;
+}
+
+export function ManageableDestinationCard({
+  destination,
+  action,
+}: ManageableDestinationCardProps) {
+  const [state, formAction, isPending] = useActionState(
+    action,
+    destinationDeleteInitialState
+  );
+
+  return (
+    <div className="space-y-3">
+      <DestinationCard destination={destination} />
+      <form
+        action={formAction}
+        className="flex flex-col gap-2 rounded-lg border border-dashed border-slate-200 bg-white/70 p-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <input type="hidden" name="destinationId" value={destination.id} />
+        <Button
+          type="submit"
+          variant="destructive"
+          size="sm"
+          disabled={isPending}
+          className="min-w-[140px]"
+        >
+          {isPending ? "Excluindo..." : "Excluir destino"}
+        </Button>
+        {state.status !== "idle" && state.message ? (
+          <p
+            className={cn(
+              "text-sm",
+              state.status === "error" ? "text-red-600" : "text-emerald-600"
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            {state.message}
+          </p>
+        ) : null}
+      </form>
+    </div>
+  );
+}

--- a/lib/destinations.ts
+++ b/lib/destinations.ts
@@ -49,6 +49,20 @@ export const destinationFormInitialState: DestinationFormState = {
   status: "idle",
 };
 
+export type DestinationDeleteState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+};
+
+export const destinationDeleteInitialState: DestinationDeleteState = {
+  status: "idle",
+};
+
+export type DestinationDeleteAction = (
+  state: DestinationDeleteState,
+  formData: FormData
+) => Promise<DestinationDeleteState>;
+
 export type SerializedDestination = {
   id: number;
   name: string;

--- a/prisma/migrations/20250204120000_add_destination_table/migration.sql
+++ b/prisma/migrations/20250204120000_add_destination_table/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "Destination" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "price" DECIMAL(65,30) NOT NULL,
+    "peopleCount" INTEGER NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "rating" DOUBLE PRECISION NOT NULL,
+    "photos" TEXT[] NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "Destination_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Destination"
+ADD CONSTRAINT "Destination_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
@@ -25,6 +25,33 @@ async function main() {
     update: { backgroundUrl: avatarUrl },
     create: { id: 1, backgroundUrl: avatarUrl },
   });
+
+  const destinationName = "Ilha dos Sonhos";
+  const hasDestination = await prisma.destination.findFirst({
+    where: { name: destinationName },
+    select: { id: true },
+  });
+
+  if (!hasDestination) {
+    await prisma.destination.create({
+      data: {
+        name: destinationName,
+        city: "Fortaleza - CE",
+        description:
+          "Uma experiência completa em um paraíso tropical com hospedagem premium, passeios guiados e gastronomia local.",
+        price: new Prisma.Decimal(2499.9),
+        peopleCount: 2,
+        startDate: new Date("2025-01-15T12:00:00.000Z"),
+        endDate: new Date("2025-01-22T12:00:00.000Z"),
+        rating: 4.8,
+        photos: [
+          "https://images.unsplash.com/photo-1500375592092-40eb2168fd21?w=1600",
+          "https://images.unsplash.com/photo-1505765050516-f72dcac9c60e?w=1600",
+        ],
+        userId: user.id,
+      },
+    });
+  }
 
   console.log(`Seed concluído. Usuário padrão: ${user.username} / ${password}`);
 }


### PR DESCRIPTION
## Summary
- add a Prisma migration and seed data to persist destination records
- use React `useActionState` in the destination form and expose a delete action with management UI
- revalidate the home and destinations pages after create/delete so both lists stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12e5945b08333a7f0ee7615b5c728