### PR TITLE
Remove Dropbox connection test section from home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 
-import { DropboxConnectionTest } from "@/components/DropboxConnectionTest";
 import { DestinationGrid } from "@/components/destinations/destination-grid";
 import { auth } from "@/lib/auth";
 import {
@@ -114,7 +113,6 @@ export default async function HomePage() {
               </div>
             </section>
 
-            <DropboxConnectionTest />
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- remove the Dropbox connection test widget from the home page so the feature is hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e145dd0b7883339d9153d734b907d8