### PR TITLE
Add Dropbox-backed image upload to destination creation

### DIFF
--- a/components/destinations/create-destination-form.tsx
+++ b/components/destinations/create-destination-form.tsx
@@ -36,6 +36,7 @@ export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
     <form
       ref={formRef}
       action={formAction}
+      encType="multipart/form-data"
       className="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
     >
       <div className="space-y-1">
@@ -209,15 +210,37 @@ export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
         </div>
 
         <div className="md:col-span-2 space-y-2">
+          <label htmlFor="photoFiles" className="text-sm font-medium text-slate-700">
+            Envie fotos do destino
+          </label>
+          <Input
+            id="photoFiles"
+            name="photoFiles"
+            type="file"
+            multiple
+            accept="image/jpeg,image/png,image/webp"
+            aria-invalid={getError("photoFiles").length > 0}
+          />
+          <p className="text-xs text-slate-500">
+            Formatos aceitos: JPG, PNG ou WebP com até 10MB por arquivo. As imagens são
+            salvas automaticamente no Dropbox quando configurado.
+          </p>
+          {getError("photoFiles").map((message) => (
+            <p key={message} className="text-xs text-red-600">
+              {message}
+            </p>
+          ))}
+        </div>
+
+        <div className="md:col-span-2 space-y-2">
           <label htmlFor="photos" className="text-sm font-medium text-slate-700">
-            URLs das fotos (uma por linha)
+            URLs das fotos (opcional, uma por linha)
           </label>
           <Textarea
             id="photos"
             name="photos"
             placeholder={"https://exemplo.com/foto-1.jpg\nhttps://exemplo.com/foto-2.jpg"}
             aria-invalid={getError("photos").length > 0}
-            required
           />
           {getError("photos").map((message) => (
             <p key={message} className="text-xs text-red-600">

--- a/lib/destinations.ts
+++ b/lib/destinations.ts
@@ -27,7 +27,7 @@ export const destinationFormSchema = z
       .max(5, "A nota máxima é 5."),
     photos: z
       .array(z.string().url("Informe URLs válidas para as fotos."))
-      .min(1, "Informe pelo menos uma foto."),
+      .min(1, "Envie pelo menos uma foto ou informe uma URL válida."),
   })
   .refine(
     (data) => data.endDate >= data.startDate,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -212,3 +212,32 @@ export async function storeBackgroundImage(ext: string, buffer: Buffer) {
   await removeByPrefix(dirPath, "background-");
   return saveLocalFile(dir, fileName, buffer);
 }
+
+export async function storeDestinationPhoto(
+  userId: string,
+  ext: string,
+  buffer: Buffer,
+  options: { originalName?: string } = {},
+) {
+  const safeUserId = sanitizeSegment(userId);
+  const baseName = options.originalName
+    ? sanitizeSegment(path.parse(options.originalName).name)
+    : "destino";
+  const fileName = `${Date.now()}-${baseName}.${ext}`;
+  const dropboxPath = `/apps/${appName}/destinations/${safeUserId}/${fileName}`;
+
+  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer, {
+    itemDescription: "foto de destino",
+    successMessage: "Upload da foto de destino concluído no Dropbox.",
+    skipMessage:
+      "Credenciais do Dropbox não configuradas. Salvando foto de destino localmente.",
+  });
+
+  if (dropboxUrl) {
+    return dropboxUrl;
+  }
+
+  const dir = ["uploads", "destinations", safeUserId];
+  const imageUrl = await saveLocalFile(dir, fileName, buffer);
+  return imageUrl;
+}


### PR DESCRIPTION
## Summary
- allow destination creation to upload image files and store them via Dropbox with a local fallback
- update the destination form UI to support file uploads alongside optional URL inputs
- refresh validation messaging for the destination photos field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14527b4b483339bce13b9b2eb8634