### PR TITLE
Optimize lucide icon imports to lighten client bundles

### DIFF
--- a/components/destinations/destination-card.tsx
+++ b/components/destinations/destination-card.tsx
@@ -3,14 +3,12 @@
 import Image from "next/image";
 import { useMemo, useState } from "react";
 
-import {
-  CalendarRange,
-  ChevronLeft,
-  ChevronRight,
-  MapPin,
-  Star,
-  Users,
-} from "lucide-react";
+import CalendarRange from "lucide-react/icons/calendar-range";
+import ChevronLeft from "lucide-react/icons/chevron-left";
+import ChevronRight from "lucide-react/icons/chevron-right";
+import MapPin from "lucide-react/icons/map-pin";
+import Star from "lucide-react/icons/star";
+import Users from "lucide-react/icons/users";
 
 import {
   Dialog,

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,15 +1,13 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import {
-  Home,
-  Info,
-  LayoutDashboard,
-  LogIn,
-  LogOut,
-  MapPin,
-  User,
-} from "lucide-react";
+import Home from "lucide-react/icons/home";
+import Info from "lucide-react/icons/info";
+import LayoutDashboard from "lucide-react/icons/layout-dashboard";
+import LogIn from "lucide-react/icons/log-in";
+import LogOut from "lucide-react/icons/log-out";
+import MapPin from "lucide-react/icons/map-pin";
+import User from "lucide-react/icons/user";
 
 import type { Session } from "next-auth";
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { LogIn, LogOut, Moon, Sun } from "lucide-react";
+import LogIn from "lucide-react/icons/log-in";
+import LogOut from "lucide-react/icons/log-out";
+import Moon from "lucide-react/icons/moon";
+import Sun from "lucide-react/icons/sun";
 import { useTheme } from "next-themes";
 import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import XIcon from "lucide-react/icons/x"
 
 import { cn } from "@/lib/utils"
 


### PR DESCRIPTION
## Summary
- replace top-level lucide-react imports with per-icon module imports across navbar, site header, destination card, and dialog components
- reduce the amount of icon metadata sent to the browser to improve build and login responsiveness

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e147c3a6548333a027fa8d8f7d8a95