### PR TITLE
Remove redundant enctype from create destination form

### DIFF
--- a/components/destinations/create-destination-form.tsx
+++ b/components/destinations/create-destination-form.tsx
@@ -36,7 +36,6 @@ export function CreateDestinationForm({ action }: CreateDestinationFormProps) {
     <form
       ref={formRef}
       action={formAction}
-      encType="multipart/form-data"
       className="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
     >
       <div className="space-y-1">


### PR DESCRIPTION
## Summary
- remove the hardcoded multipart encoding from the destination creation form so React can manage it for server actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e148aa3c688333a6c53d85d5e98738