### PR TITLE
Fix lucide icon imports to root entry point

### DIFF
--- a/components/destinations/destination-card.tsx
+++ b/components/destinations/destination-card.tsx
@@ -3,12 +3,14 @@
 import Image from "next/image";
 import { useMemo, useState } from "react";
 
-import CalendarRange from "lucide-react/icons/calendar-range";
-import ChevronLeft from "lucide-react/icons/chevron-left";
-import ChevronRight from "lucide-react/icons/chevron-right";
-import MapPin from "lucide-react/icons/map-pin";
-import Star from "lucide-react/icons/star";
-import Users from "lucide-react/icons/users";
+import {
+  CalendarRange,
+  ChevronLeft,
+  ChevronRight,
+  MapPin,
+  Star,
+  Users,
+} from "lucide-react";
 
 import {
   Dialog,

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,13 +1,15 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import Home from "lucide-react/icons/home";
-import Info from "lucide-react/icons/info";
-import LayoutDashboard from "lucide-react/icons/layout-dashboard";
-import LogIn from "lucide-react/icons/log-in";
-import LogOut from "lucide-react/icons/log-out";
-import MapPin from "lucide-react/icons/map-pin";
-import User from "lucide-react/icons/user";
+import {
+  Home,
+  Info,
+  LayoutDashboard,
+  LogIn,
+  LogOut,
+  MapPin,
+  User,
+} from "lucide-react";
 
 import type { Session } from "next-auth";
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import LogIn from "lucide-react/icons/log-in";
-import LogOut from "lucide-react/icons/log-out";
-import Moon from "lucide-react/icons/moon";
-import Sun from "lucide-react/icons/sun";
+import { LogIn, LogOut, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import XIcon from "lucide-react/icons/x"
+import { X as XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 


### PR DESCRIPTION
## Summary
- update icon imports to use the `lucide-react` entry point across navigation, destination card, and dialog components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1499463e08333ac58e256009aa119