### PR TITLE
Fix Prisma client typing

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,11 +1,13 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 declare global {
-  var prismaGlobal: PrismaClient | undefined;
+  var prismaGlobal: Prisma.DefaultPrismaClient | undefined;
 }
 
-export const prisma = globalThis.prismaGlobal ?? new PrismaClient();
+const prismaClient = globalThis.prismaGlobal ?? new PrismaClient();
+
+export const prisma: Prisma.DefaultPrismaClient = prismaClient;
 
 if (process.env.NODE_ENV !== "production") {
-  globalThis.prismaGlobal = prisma;
+  globalThis.prismaGlobal = prismaClient;
 }


### PR DESCRIPTION
## Summary
- ensure the shared Prisma client is typed as Prisma.DefaultPrismaClient so generated delegates are available
- reuse a single Prisma client instance in development without type narrowing issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14ae5a28c8333aea73e68779a9d7d