### PR TITLE
Fix Prisma client typing

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,12 +1,12 @@
-import { Prisma, PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
 declare global {
-  var prismaGlobal: Prisma.DefaultPrismaClient | undefined;
+  var prismaGlobal: PrismaClient | undefined;
 }
 
 const prismaClient = globalThis.prismaGlobal ?? new PrismaClient();
 
-export const prisma: Prisma.DefaultPrismaClient = prismaClient;
+export const prisma = prismaClient;
 
 if (process.env.NODE_ENV !== "production") {
   globalThis.prismaGlobal = prismaClient;


### PR DESCRIPTION
## Summary
- update the Prisma singleton helper to use PrismaClient typing
- ensure the exported client exposes the Destination delegate used on the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14dfb4e748333a340b0316f95f4d7