### PR TITLE
Refine Prisma client typing for destination delegate

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -4,10 +4,11 @@ declare global {
   var prismaGlobal: Prisma.DefaultPrismaClient | undefined;
 }
 
-const prismaClient = globalThis.prismaGlobal ?? new PrismaClient();
+const prismaClient =
+  globalThis.prismaGlobal ?? (new PrismaClient() as Prisma.DefaultPrismaClient);
 
-export const prisma: Prisma.DefaultPrismaClient = prismaClient;
+export const prisma = prismaClient satisfies Prisma.DefaultPrismaClient;
 
 if (process.env.NODE_ENV !== "production") {
-  globalThis.prismaGlobal = prismaClient;
+  globalThis.prismaGlobal = prisma;
 }


### PR DESCRIPTION
## Summary
- tighten the Prisma singleton typing to rely on `Prisma.DefaultPrismaClient`
- ensure the cached global client reference preserves the destination delegate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14dfb4e748333a340b0316f95f4d7