### PR TITLE
Ensure Prisma client retains generated delegates

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,14 +1,13 @@
 import { PrismaClient } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 
-declare global {
-  var prismaGlobal: PrismaClient | undefined;
-}
+type PrismaGlobal = { prisma?: Prisma.DefaultPrismaClient };
 
-const prismaClient =
-  globalThis.prismaGlobal ?? (new PrismaClient() as Prisma.DefaultPrismaClient);
+const globalForPrisma = globalThis as typeof globalThis & PrismaGlobal;
 
-export const prisma = prismaClient satisfies Prisma.DefaultPrismaClient;
+export const prisma: Prisma.DefaultPrismaClient =
+  globalForPrisma.prisma ?? new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") {
-  globalThis.prismaGlobal = prisma;
+  globalForPrisma.prisma = prisma;
 }


### PR DESCRIPTION
## Summary
- type the Prisma singleton with `Prisma.DefaultPrismaClient` using a type-only namespace import
- keep the cached Prisma instance on the global object so generated delegates like `destination` stay available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e151a97fb8833398f2726291393c21