### PR TITLE
Fix Dropbox destination photo uploads

### DIFF
--- a/app/destinos/page.tsx
+++ b/app/destinos/page.tsx
@@ -15,6 +15,8 @@ import { prisma } from "@/lib/prisma";
 import { assertImage, sanitizeExt } from "@/lib/file";
 import { storeDestinationPhoto } from "@/lib/storage";
 
+export const runtime = "nodejs";
+
 // Ação server-side responsável por criar novos destinos a partir do formulário da página.
 async function createDestination(
   _prevState: DestinationFormState,

--- a/lib/destinations.ts
+++ b/lib/destinations.ts
@@ -1,6 +1,28 @@
 import type { Destination } from "@prisma/client";
 import { z } from "zod";
 
+const photoUrlSchema = z
+  .string()
+  .trim()
+  .refine(
+    (value) => {
+      if (!value) {
+        return false;
+      }
+
+      try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+      } catch {
+        return value.startsWith("/");
+      }
+    },
+    {
+      message:
+        "Informe URLs completas (http/https) ou caminhos relativos gerados pelo sistema.",
+    },
+  );
+
 export const destinationFormSchema = z
   .object({
     name: z.string().min(1, "O nome do destino é obrigatório.").trim(),
@@ -25,9 +47,10 @@ export const destinationFormSchema = z
       .number({ invalid_type_error: "Informe uma nota válida." })
       .min(0, "A nota mínima é 0.")
       .max(5, "A nota máxima é 5."),
-    photos: z
-      .array(z.string().url("Informe URLs válidas para as fotos."))
-      .min(1, "Envie pelo menos uma foto ou informe uma URL válida."),
+    photos: z.array(photoUrlSchema).min(
+      1,
+      "Envie pelo menos uma foto ou informe uma URL válida.",
+    ),
   })
   .refine(
     (data) => data.endDate >= data.startDate,

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,13 +1,10 @@
 import { PrismaClient } from "@prisma/client";
-import type { Prisma } from "@prisma/client";
 
-type PrismaGlobal = { prisma?: Prisma.DefaultPrismaClient };
-
+type PrismaGlobal = { prisma?: PrismaClient };
 
 const globalForPrisma = globalThis as typeof globalThis & PrismaGlobal;
 
-export const prisma: Prisma.DefaultPrismaClient =
-  globalForPrisma.prisma ?? new PrismaClient();
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- force the destinos page to run on the Node.js runtime so file uploads can use the filesystem and Dropbox SDK
- allow the destination form schema to accept generated relative URLs in addition to full http/https links
- adjust the Prisma client helper to retain the destination delegate type information

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e156cbed808333ac5c0138cacf012c