### PR TITLE
Enforce Dropbox-only uploads with detailed error reporting

### DIFF
--- a/app/api/background/route.ts
+++ b/app/api/background/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 import { prisma } from "@/lib/prisma";
-import { storeBackgroundImage } from "@/lib/storage";
+import { DropboxUploadError, storeBackgroundImage } from "@/lib/storage";
 import { assertImage, sanitizeExt } from "@/lib/file";
 
 const RATE_LIMIT_WINDOW = 10 * 60 * 1000;
@@ -101,6 +101,24 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ backgroundUrl });
   } catch (error) {
     console.error("Erro ao atualizar background", error);
+
+    if (error instanceof DropboxUploadError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+          errorDetails: {
+            message: error.message,
+            stack: error.stack,
+            stage: error.stage,
+            dropboxPath: error.dropboxPath,
+            causeMessage: error.causeMessage,
+            causeStack: error.causeStack,
+          },
+        },
+        { status: 500 },
+      );
+    }
+
     return NextResponse.json({ error: "Erro ao atualizar background" }, { status: 500 });
   }
 }

--- a/app/api/profile/photo/route.ts
+++ b/app/api/profile/photo/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { storeProfileImage } from "@/lib/storage";
-import { UploadLogEntry } from "@/types/upload";
+import { DropboxUploadError, storeProfileImage } from "@/lib/storage";
+import { UploadLogEntry, UploadErrorDetails } from "@/types/upload";
 import { assertImage, sanitizeExt } from "@/lib/file";
 
 export async function POST(request: Request) {
@@ -57,12 +57,33 @@ export async function POST(request: Request) {
     return NextResponse.json({ imageUrl: updated.imageUrl, logs });
   } catch (error) {
     console.error("Erro ao atualizar foto de perfil", error);
-    logs.push({
+
+    let responseLogs: UploadLogEntry[] = [...logs];
+    let errorDetails: UploadErrorDetails | undefined;
+    let errorMessage = "Erro ao enviar arquivo";
+
+    if (error instanceof DropboxUploadError) {
+      responseLogs = [...error.uploadLogs];
+      errorMessage = error.message;
+      errorDetails = {
+        message: error.message,
+        stack: error.stack,
+        stage: error.stage,
+        dropboxPath: error.dropboxPath,
+        causeMessage: error.causeMessage,
+        causeStack: error.causeStack,
+      };
+    }
+
+    responseLogs.push({
       level: "error",
       message: "Falha ao atualizar a foto de perfil. Tente novamente.",
       timestamp: new Date().toISOString(),
     });
 
-    return NextResponse.json({ error: "Erro ao enviar arquivo", logs }, { status: 500 });
+    return NextResponse.json(
+      { error: errorMessage, logs: responseLogs, errorDetails },
+      { status: 500 },
+    );
   }
 }

--- a/components/ChangeBackground.tsx
+++ b/components/ChangeBackground.tsx
@@ -3,6 +3,10 @@
 import { FormEvent, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
+import type { UploadErrorDetails } from "@/types/upload";
+import { normalizeUploadErrorDetails } from "@/lib/upload-error";
+import { UploadErrorDialog } from "./UploadErrorDialog";
+
 type Mode = "url" | "upload";
 
 export function ChangeBackground({
@@ -17,6 +21,10 @@ export function ChangeBackground({
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [errorDetails, setErrorDetails] = useState<UploadErrorDetails | null>(
+    null,
+  );
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
 
   if (!isAuthenticated) {
     return null;
@@ -26,6 +34,8 @@ export function ChangeBackground({
     event.preventDefault();
     setMessage(null);
     setError(null);
+    setErrorDetails(null);
+    setIsErrorDialogOpen(false);
 
     startTransition(async () => {
       try {
@@ -55,6 +65,14 @@ export function ChangeBackground({
         const data = await response.json();
         if (!response.ok) {
           setError(data.error ?? "Erro ao atualizar background");
+          const normalizedDetails = normalizeUploadErrorDetails(
+            data.errorDetails,
+          );
+
+          if (normalizedDetails) {
+            setErrorDetails(normalizedDetails);
+            setIsErrorDialogOpen(true);
+          }
           return;
         }
 
@@ -143,6 +161,16 @@ export function ChangeBackground({
         {message && <p className="text-sm text-green-600">{message}</p>}
         {error && <p className="text-sm text-red-600">{error}</p>}
       </form>
+      <UploadErrorDialog
+        open={isErrorDialogOpen}
+        onOpenChange={(open) => {
+          setIsErrorDialogOpen(open);
+          if (!open) {
+            setErrorDetails(null);
+          }
+        }}
+        details={errorDetails}
+      />
     </div>
   );
 }

--- a/components/ChangePhoto.tsx
+++ b/components/ChangePhoto.tsx
@@ -3,7 +3,13 @@
 import { FormEvent, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
-import type { UploadLogEntry, UploadLogLevel } from "@/types/upload";
+import type {
+  UploadErrorDetails,
+  UploadLogEntry,
+  UploadLogLevel,
+} from "@/types/upload";
+import { normalizeUploadErrorDetails } from "@/lib/upload-error";
+import { UploadErrorDialog } from "./UploadErrorDialog";
 
 type UploadAttemptStatus = "pending" | "success" | "error";
 
@@ -91,12 +97,18 @@ export function ChangePhoto() {
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const [attempts, setAttempts] = useState<UploadAttempt[]>([]);
+  const [errorDetails, setErrorDetails] = useState<UploadErrorDetails | null>(
+    null,
+  );
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     const form = event.currentTarget;
     event.preventDefault();
     setMessage(null);
     setError(null);
+    setErrorDetails(null);
+    setIsErrorDialogOpen(false);
 
     if (!file) {
       setError("Selecione uma imagem primeiro.");
@@ -147,6 +159,10 @@ export function ChangePhoto() {
         const serverLogs = normalizeServerLogs(data.logs);
 
         if (!response.ok) {
+          const normalizedDetails = normalizeUploadErrorDetails(
+            data.errorDetails,
+          );
+
           appendToAttempt(
             [
               ...serverLogs,
@@ -155,6 +171,11 @@ export function ChangePhoto() {
             "error",
           );
           setError(data.error ?? "Erro ao enviar foto.");
+
+          if (normalizedDetails) {
+            setErrorDetails(normalizedDetails);
+            setIsErrorDialogOpen(true);
+          }
           return;
         }
 
@@ -218,6 +239,16 @@ export function ChangePhoto() {
       </form>
 
       <UploadLogPanel attempts={sortedAttempts} />
+      <UploadErrorDialog
+        open={isErrorDialogOpen}
+        onOpenChange={(open) => {
+          setIsErrorDialogOpen(open);
+          if (!open) {
+            setErrorDetails(null);
+          }
+        }}
+        details={errorDetails}
+      />
     </div>
   );
 }

--- a/components/UploadErrorDialog.tsx
+++ b/components/UploadErrorDialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { UploadErrorDetails } from "@/types/upload";
+
+interface UploadErrorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  details: UploadErrorDetails | null;
+}
+
+const stageLabels: Record<string, string> = {
+  credentials: "Verificação das credenciais do Dropbox",
+  client_initialization: "Inicialização do cliente do Dropbox",
+  upload: "Envio do arquivo para o Dropbox",
+};
+
+function formatStage(stage?: string) {
+  if (!stage) {
+    return null;
+  }
+
+  return stageLabels[stage] ?? stage;
+}
+
+export function UploadErrorDialog({
+  open,
+  onOpenChange,
+  details,
+}: UploadErrorDialogProps) {
+  const formattedStage = formatStage(details?.stage);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto" showCloseButton>
+        <DialogHeader>
+          <DialogTitle>Falha ao salvar arquivo no Dropbox</DialogTitle>
+          <DialogDescription>
+            Não foi possível concluir o upload. Confira os detalhes técnicos abaixo
+            e tente novamente após corrigir o problema.
+          </DialogDescription>
+        </DialogHeader>
+
+        {details ? (
+          <div className="space-y-4 text-sm text-slate-700">
+            <div>
+              <h4 className="text-sm font-semibold text-slate-900">
+                Motivo principal
+              </h4>
+              <p className="mt-1 whitespace-pre-line break-words">
+                {details.message}
+              </p>
+            </div>
+
+            {formattedStage && (
+              <div>
+                <h4 className="text-sm font-semibold text-slate-900">
+                  Etapa afetada
+                </h4>
+                <p className="mt-1 break-words">{formattedStage}</p>
+              </div>
+            )}
+
+            {details.dropboxPath && (
+              <div>
+                <h4 className="text-sm font-semibold text-slate-900">
+                  Caminho no Dropbox
+                </h4>
+                <p className="mt-1 break-all font-mono text-xs text-slate-600">
+                  {details.dropboxPath}
+                </p>
+              </div>
+            )}
+
+            {details.causeMessage && (
+              <div>
+                <h4 className="text-sm font-semibold text-slate-900">
+                  Detalhes do erro interno
+                </h4>
+                <p className="mt-1 whitespace-pre-line break-words">
+                  {details.causeMessage}
+                </p>
+              </div>
+            )}
+
+            {details.stack && (
+              <div>
+                <h4 className="text-sm font-semibold text-slate-900">Stack trace</h4>
+                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-slate-900/90 p-3 text-xs text-slate-100">
+                  {details.stack}
+                </pre>
+              </div>
+            )}
+
+            {details.causeStack && (
+              <div>
+                <h4 className="text-sm font-semibold text-slate-900">
+                  Stack trace da causa
+                </h4>
+                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-slate-900/80 p-3 text-xs text-slate-100">
+                  {details.causeStack}
+                </pre>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-600">
+            Não foi possível recuperar detalhes adicionais sobre a falha.
+          </p>
+        )}
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Fechar
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,8 +1,50 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 
 import { UploadLogEntry } from "@/types/upload";
 import { getDropboxCredentialsStatus } from "./dropbox";
+
+export type DropboxUploadStage =
+  | "credentials"
+  | "client_initialization"
+  | "upload";
+
+export class DropboxUploadError extends Error {
+  readonly stage: DropboxUploadStage;
+  readonly dropboxPath: string;
+  readonly uploadLogs: UploadLogEntry[];
+  readonly causeMessage?: string;
+  readonly causeStack?: string;
+
+  constructor(
+    message: string,
+    {
+      stage,
+      dropboxPath,
+      logs,
+      cause,
+    }: {
+      stage: DropboxUploadStage;
+      dropboxPath: string;
+      logs?: UploadLogEntry[];
+      cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = "DropboxUploadError";
+    this.stage = stage;
+    this.dropboxPath = dropboxPath;
+    this.uploadLogs = logs ?? [];
+
+    if (cause instanceof Error) {
+      this.causeMessage = cause.message;
+      this.causeStack = cause.stack;
+    } else if (typeof cause === "string") {
+      this.causeMessage = cause;
+    }
+
+    Object.setPrototypeOf(this, DropboxUploadError.prototype);
+  }
+}
 
 const appName = process.env.APP_NAME ?? "next-profile-bg";
 
@@ -18,30 +60,30 @@ interface DropboxUploadOptions {
   logs?: UploadLogEntry[];
   itemDescription?: string;
   successMessage?: string;
-  skipMessage?: string;
 }
 
 async function tryDropboxUpload(
   dropboxPath: string,
   buffer: Buffer,
-  { logs, itemDescription = "arquivo", successMessage, skipMessage }: DropboxUploadOptions = {},
-) {
+  { logs, itemDescription = "arquivo", successMessage }: DropboxUploadOptions = {},
+): Promise<string> {
   const description = itemDescription;
+  const logEntries = logs ?? [];
 
-  logs?.push(
+  logEntries.push(
     createLog("info", "Verificando configuração das credenciais do Dropbox..."),
   );
 
   const credentials = getDropboxCredentialsStatus();
   if (!credentials.configured) {
-    logs?.push(
-      createLog(
-        "warning",
-        skipMessage ??
-          "Credenciais do Dropbox não configuradas. O arquivo será salvo localmente.",
-      ),
-    );
-    return null;
+    const message =
+      "Credenciais do Dropbox não configuradas. Configure-as antes de tentar novamente.";
+    logEntries.push(createLog("error", message));
+    throw new DropboxUploadError(message, {
+      stage: "credentials",
+      dropboxPath,
+      logs: logEntries,
+    });
   }
 
   const authDescription =
@@ -51,20 +93,20 @@ async function tryDropboxUpload(
         ? "via token de acesso"
         : "em modo desconhecido";
 
-  logs?.push(
+  logEntries.push(
     createLog(
       "success",
       `Credenciais do Dropbox configuradas (${authDescription}).`,
     ),
   );
 
-  logs?.push(createLog("info", "Inicializando cliente do Dropbox..."));
+  logEntries.push(createLog("info", "Inicializando cliente do Dropbox..."));
 
   let dropbox: typeof import("./dropbox") | null = null;
   try {
     dropbox = await import("./dropbox");
     dropbox.getDropbox();
-    logs?.push(
+    logEntries.push(
       createLog(
         "success",
         "Cliente do Dropbox inicializado com sucesso.",
@@ -73,20 +115,27 @@ async function tryDropboxUpload(
   } catch (error) {
     const message = error instanceof Error ? error.message : "Erro desconhecido";
     console.error("Falha ao inicializar cliente do Dropbox", error);
-    logs?.push(
-      createLog(
-        "error",
-        `Falha ao inicializar o cliente do Dropbox: ${message}. Prosseguindo com armazenamento local.`,
-      ),
-    );
-    return null;
+    const logMessage = `Falha ao inicializar o cliente do Dropbox: ${message}.`;
+    logEntries.push(createLog("error", logMessage));
+    throw new DropboxUploadError(logMessage, {
+      stage: "client_initialization",
+      dropboxPath,
+      logs: logEntries,
+      cause: error,
+    });
   }
 
   if (!dropbox) {
-    return null;
+    const message = "Cliente do Dropbox não foi inicializado.";
+    logEntries.push(createLog("error", message));
+    throw new DropboxUploadError(message, {
+      stage: "client_initialization",
+      dropboxPath,
+      logs: logEntries,
+    });
   }
 
-  logs?.push(
+  logEntries.push(
     createLog(
       "info",
       `Enviando ${description} para o Dropbox no caminho ${dropboxPath}...`,
@@ -105,11 +154,11 @@ async function tryDropboxUpload(
             ? "Dropbox não autorizou a criação do link compartilhado. Usando proxy interno."
             : "Não foi possível gerar link compartilhado no Dropbox. Usando proxy interno.";
 
-      logs?.push(createLog("warning", warningMessage));
+      logEntries.push(createLog("warning", warningMessage));
       publicUrl = dropbox.createProxyUrl(result.path, Date.now());
     }
 
-    logs?.push(
+    logEntries.push(
       createLog("success", successMessage ?? "Upload concluído no Dropbox."),
     );
 
@@ -117,44 +166,15 @@ async function tryDropboxUpload(
   } catch (error) {
     const message = error instanceof Error ? error.message : "Erro desconhecido";
     console.error("Falha ao enviar arquivo ao Dropbox", error);
-    logs?.push(
-      createLog(
-        "error",
-        `Falha ao enviar ${description} para o Dropbox: ${message}. Prosseguindo com armazenamento local.`,
-      ),
-    );
-    return null;
+    const errorMessage = `Falha ao enviar ${description} para o Dropbox: ${message}.`;
+    logEntries.push(createLog("error", errorMessage));
+    throw new DropboxUploadError(errorMessage, {
+      stage: "upload",
+      dropboxPath,
+      logs: logEntries,
+      cause: error,
+    });
   }
-}
-
-async function ensureDir(dirSegments: string[]) {
-  const dirPath = path.join(process.cwd(), "public", ...dirSegments);
-  await fs.mkdir(dirPath, { recursive: true });
-  return dirPath;
-}
-
-async function removeByPrefix(dirPath: string, prefix: string) {
-  try {
-    const entries = await fs.readdir(dirPath);
-    await Promise.all(
-      entries
-        .filter((entry) => entry.startsWith(prefix))
-        .map((entry) => fs.rm(path.join(dirPath, entry)).catch(() => undefined)),
-    );
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
-      console.error("Falha ao remover arquivos antigos", error);
-    }
-  }
-}
-
-async function saveLocalFile(dirSegments: string[], fileName: string, buffer: Buffer) {
-  const dirPath = await ensureDir(dirSegments);
-  await fs.writeFile(path.join(dirPath, fileName), buffer);
-  const urlPath = ["", ...dirSegments, fileName]
-    .map((segment) => segment.replace(/\\/g, "/"))
-    .join("/");
-  return `${urlPath}?v=${Date.now()}`;
 }
 
 function sanitizeSegment(value: string) {
@@ -170,47 +190,17 @@ export async function storeProfileImage(userId: string, ext: string, buffer: Buf
     logs,
     itemDescription: "foto de perfil",
     successMessage: "Upload da foto concluído no Dropbox.",
-    skipMessage:
-      "Credenciais do Dropbox não configuradas. Salvando foto de perfil localmente.",
   });
 
-  if (dropboxUrl) {
-    return { imageUrl: dropboxUrl, logs };
-  }
-
-  logs.push(createLog("info", "Preparando armazenamento local para a foto de perfil..."));
-
-  const dir = ["uploads", "profiles"];
-  const safeId = sanitizeSegment(userId);
-  const fileName = `${safeId}-${Date.now()}.${ext}`;
-  const dirPath = path.join(process.cwd(), "public", ...dir);
-
-  await removeByPrefix(dirPath, `${safeId}-`);
-  logs.push(createLog("info", "Fotos antigas removidas do armazenamento local."));
-
-  const imageUrl = await saveLocalFile(dir, fileName, buffer);
-  logs.push(createLog("success", "Foto salva com sucesso no armazenamento local."));
-
-  return { imageUrl, logs };
+  return { imageUrl: dropboxUrl, logs };
 }
 
 export async function storeBackgroundImage(ext: string, buffer: Buffer) {
   const dropboxPath = `/apps/${appName}/backgrounds/current.${ext}`;
-  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer, {
+  return tryDropboxUpload(dropboxPath, buffer, {
     itemDescription: "background",
     successMessage: "Upload do background concluído no Dropbox.",
-    skipMessage:
-      "Credenciais do Dropbox não configuradas. Salvando background localmente.",
   });
-  if (dropboxUrl) {
-    return dropboxUrl;
-  }
-
-  const dir = ["uploads", "backgrounds"];
-  const fileName = `background-${Date.now()}.${ext}`;
-  const dirPath = path.join(process.cwd(), "public", ...dir);
-  await removeByPrefix(dirPath, "background-");
-  return saveLocalFile(dir, fileName, buffer);
 }
 
 export async function storeDestinationPhoto(
@@ -226,18 +216,8 @@ export async function storeDestinationPhoto(
   const fileName = `${Date.now()}-${baseName}.${ext}`;
   const dropboxPath = `/apps/${appName}/destinations/${safeUserId}/${fileName}`;
 
-  const dropboxUrl = await tryDropboxUpload(dropboxPath, buffer, {
+  return tryDropboxUpload(dropboxPath, buffer, {
     itemDescription: "foto de destino",
     successMessage: "Upload da foto de destino concluído no Dropbox.",
-    skipMessage:
-      "Credenciais do Dropbox não configuradas. Salvando foto de destino localmente.",
   });
-
-  if (dropboxUrl) {
-    return dropboxUrl;
-  }
-
-  const dir = ["uploads", "destinations", safeUserId];
-  const imageUrl = await saveLocalFile(dir, fileName, buffer);
-  return imageUrl;
 }

--- a/lib/upload-error.ts
+++ b/lib/upload-error.ts
@@ -1,0 +1,40 @@
+import { UploadErrorDetails } from "@/types/upload";
+
+export function normalizeUploadErrorDetails(value: unknown): UploadErrorDetails | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Partial<Record<string, unknown>>;
+  const message = record.message;
+
+  if (typeof message !== "string" || message.trim().length === 0) {
+    return null;
+  }
+
+  const details: UploadErrorDetails = {
+    message,
+  };
+
+  if (typeof record.stack === "string") {
+    details.stack = record.stack;
+  }
+
+  if (typeof record.stage === "string") {
+    details.stage = record.stage;
+  }
+
+  if (typeof record.dropboxPath === "string") {
+    details.dropboxPath = record.dropboxPath;
+  }
+
+  if (typeof record.causeMessage === "string") {
+    details.causeMessage = record.causeMessage;
+  }
+
+  if (typeof record.causeStack === "string") {
+    details.causeStack = record.causeStack;
+  }
+
+  return details;
+}

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -5,3 +5,18 @@ export interface UploadLogEntry {
   level: UploadLogLevel;
   timestamp: string;
 }
+
+export type UploadErrorStage =
+  | "credentials"
+  | "client_initialization"
+  | "upload"
+  | string;
+
+export interface UploadErrorDetails {
+  message: string;
+  stack?: string;
+  stage?: UploadErrorStage;
+  dropboxPath?: string;
+  causeMessage?: string;
+  causeStack?: string;
+}


### PR DESCRIPTION
## Summary
- require Dropbox uploads by removing local storage fallbacks and surfacing detailed failure context through a new error class
- return structured Dropbox error details from the background and profile upload APIs for client consumption
- add a reusable upload error dialog and wire it into the photo and background clients with helper normalization logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e15989d81483339f5b65570829c084