### PR TITLE
Handle Dropbox shared link scope fallback

### DIFF
--- a/lib/dropbox.ts
+++ b/lib/dropbox.ts
@@ -192,7 +192,24 @@ async function withDropboxClient<T>(
 export interface DropboxUploadResult {
   path: string;
   sharedUrl: string | null;
-  warning?: "missing_scope" | "auth";
+  warning?:
+    | "missing_scope"
+    | "auth"
+    | "missing_scope_temporary_link";
+}
+
+async function createTemporaryLink(client: Dropbox, path: string) {
+  try {
+    const response = await client.filesGetTemporaryLink({ path });
+    return normalizeSharedUrl(response.result.link);
+  } catch (error) {
+    if (isAuthError(error)) {
+      throw error;
+    }
+
+    console.error("Falha ao gerar link temporário do Dropbox", error);
+    return null;
+  }
 }
 
 export async function uploadBuffer(
@@ -220,6 +237,15 @@ export async function uploadBuffer(
       };
     } catch (error) {
       if (isMissingScopeError(error)) {
+        const temporary = await createTemporaryLink(client, path);
+        if (temporary) {
+          return {
+            path,
+            sharedUrl: temporary,
+            warning: "missing_scope_temporary_link",
+          };
+        }
+
         return { path, sharedUrl: null, warning: "missing_scope" };
       }
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -156,6 +156,13 @@ async function tryDropboxUpload(
 
       logEntries.push(createLog("warning", warningMessage));
       publicUrl = dropbox.createProxyUrl(result.path, Date.now());
+    } else if (result.warning === "missing_scope_temporary_link") {
+      logEntries.push(
+        createLog(
+          "warning",
+          "Dropbox sem permissão para criar links compartilhados. Gerando link temporário diretamente do Dropbox.",
+        ),
+      );
     }
 
     logEntries.push(


### PR DESCRIPTION
## Summary
- generate a temporary Dropbox link when shared link creation fails due to missing sharing scopes
- log a specific warning when falling back to the temporary Dropbox link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1994b07b8833392006856a45de438