### PR TITLE
Fix lint warnings on destinos page

### DIFF
--- a/app/destinos/page.tsx
+++ b/app/destinos/page.tsx
@@ -1,14 +1,11 @@
 import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { 
-  Plane, 
-  MapPin, 
-  Calendar, 
-  Users, 
-  Star, 
-  Ship, 
-  Luggage, 
-  Globe, 
+  Plane,
+  MapPin,
+  Ship,
+  Luggage,
+  Globe,
   Sparkles,
   TrendingUp,
   Heart,
@@ -18,7 +15,6 @@ import {
   Mail,
   MessageCircle,
   ChevronRight,
-  Check,
   Compass,
   Waves,
   Mountain,


### PR DESCRIPTION
## Summary
- remove unused icon imports from the destinos page so eslint no longer reports unused variables

## Testing
- npm run lint *(fails: existing lint error in app/sobre-nos/page.tsx and warnings in components/navbar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b64cea608333a79eea8474c6083e