### PR TITLE
Remove unused ts-expect-error directive from dashboard page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -100,7 +100,6 @@ export default async function DashboardPage() {
                     {/* Usamos Image para carregar com qualidade se for permitido; se não, cai no bg div */}
                     {/* Como backgroundUrl vem do banco e pode ser externo, o Next/Image pode precisar de domain config.
                         Se não estiver configurado, substitua por um <div style={{ backgroundImage }} /> como seu original. */}
-                    {/* @ts-expect-error - caso o domínio não esteja na config, troque para <div> abaixo */}
                     <Image
                       src={backgroundUrl}
                       alt="Background atual"


### PR DESCRIPTION
## Summary
- remove the unused `@ts-expect-error` directive before the dashboard background preview image

## Testing
- npm run lint *(fails: pre-existing lint warnings and an `no-explicit-any` error in app/sobre-nos/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b63ec4d88333b6a659a6a780ea2f