### PR TITLE
Fix navbar type errors and replace img elements

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -186,9 +186,12 @@ export function Navbar({ user }: NavbarProps) {
                     className="group/user inline-flex items-center gap-2.5 rounded-full border border-white/10 bg-gradient-to-br from-white/[0.05] to-white/[0.02] px-3 py-2 text-sm font-medium shadow-[inset_0_1px_0_theme(colors.white/10)] transition-all duration-300 hover:-translate-y-0.5 hover:border-cyan-400/30 hover:bg-cyan-500/5 hover:shadow-lg hover:shadow-cyan-500/10"
                   >
                     {user?.image ? (
-                      <img
+                      <Image
                         src={user.image}
                         alt={userDisplayName}
+                        width={32}
+                        height={32}
+                        unoptimized
                         className="size-8 rounded-full border-2 border-white/20 object-cover ring-2 ring-cyan-400/20 transition-all duration-300 group-hover/user:scale-[1.08] group-hover/user:border-cyan-400/40 group-hover/user:ring-cyan-400/40"
                       />
                     ) : (
@@ -324,9 +327,12 @@ export function Navbar({ user }: NavbarProps) {
                   <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.05] to-white/[0.02] p-4 shadow-[inset_0_1px_0_theme(colors.white/10)]">
                     <div className="mb-3 flex items-center gap-3">
                       {user?.image ? (
-                        <img
+                        <Image
                           src={user.image}
                           alt={userDisplayName}
+                          width={48}
+                          height={48}
+                          unoptimized
                           className="size-12 rounded-full border-2 border-white/20 object-cover ring-2 ring-cyan-400/20"
                         />
                       ) : (

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -6,6 +6,7 @@ declare module "next-auth" {
     user: {
       id: string;
       name?: string | null;
+      email?: string | null;
       image?: string | null;
     };
   }


### PR DESCRIPTION
## Summary
- extend the session user type with an optional email field so the navbar can access it safely
- replace raw img tags in the navbar with Next.js Image components sized for desktop and mobile avatars

## Testing
- `npm run lint` *(fails: existing lint error in app/sobre-nos/page.tsx complaining about unexpected any and unused icons)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b666df388333ad9026c156b23487