### PR TITLE
Fix Prisma destination typings and adjust in-view helper

### DIFF
--- a/app/sobre-nos/page.tsx
+++ b/app/sobre-nos/page.tsx
@@ -30,7 +30,7 @@ import { cn } from "@/lib/utils";
 
 // --- Helpers de animação simples ---
 function useInView<T extends HTMLElement>(
-  ref: React.RefObject<T>,
+  ref: React.RefObject<T | null>,
   margin = "0px 0px -20% 0px"
 ) {
   const [inView, setInView] = useState(false);

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,10 +1,15 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
-type PrismaGlobal = { prisma?: PrismaClient };
+type ExtendedPrismaClient = PrismaClient & {
+  destination: Prisma.DestinationDelegate;
+};
+
+type PrismaGlobal = { prisma?: ExtendedPrismaClient };
 
 const globalForPrisma = globalThis as typeof globalThis & PrismaGlobal;
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+export const prisma =
+  globalForPrisma.prisma ?? (new PrismaClient() as ExtendedPrismaClient);
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- ensure the Prisma singleton exposes the destination delegate so destination queries type-check
- relax the about page in-view helper to accept refs that start as null

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b8f362008333b4fa906d0e2236c0