### PR TITLE
Simplify Prisma client typing

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,15 +1,10 @@
-import { Prisma, PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
-type ExtendedPrismaClient = PrismaClient & {
-  destination: Prisma.DestinationDelegate;
-};
-
-type PrismaGlobal = { prisma?: ExtendedPrismaClient };
+type PrismaGlobal = { prisma?: PrismaClient };
 
 const globalForPrisma = globalThis as typeof globalThis & PrismaGlobal;
 
-export const prisma =
-  globalForPrisma.prisma ?? (new PrismaClient() as ExtendedPrismaClient);
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- remove the custom Prisma client extension referencing a missing delegate
- rely on the generated PrismaClient type for destination model access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b9e319bc8333a5b617a89c36e697