### PR TITLE
Fix Prisma client typing for Destination delegate

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,11 +1,10 @@
 import { PrismaClient } from "@prisma/client";
-import type { Prisma } from "@prisma/client";
 
-type PrismaGlobal = { prisma?: Prisma.DefaultPrismaClient };
+type PrismaGlobal = { prisma?: PrismaClient };
 
 const globalForPrisma = globalThis as typeof globalThis & PrismaGlobal;
-export const prisma: Prisma.DefaultPrismaClient =
-  globalForPrisma.prisma ?? new PrismaClient();
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/types/prisma-client.d.ts
+++ b/types/prisma-client.d.ts
@@ -1,0 +1,7 @@
+import type { Prisma } from "@prisma/client";
+
+declare module "@prisma/client" {
+  interface PrismaClient {
+    destination: Prisma.DestinationDelegate;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure the Prisma singleton uses the concrete PrismaClient type
- add a module augmentation so the Destination delegate is always typed on the client instance

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e1bc9f38208333b5126ca7ad405ae2