### PR TITLE
Ensure background updates sync across carousel pages

### DIFF
--- a/app/api/background/route.ts
+++ b/app/api/background/route.ts
@@ -51,6 +51,23 @@ const urlSchema = z.object({
     .refine((value) => value.startsWith("https://"), "Use uma URL com HTTPS"),
 });
 
+export async function GET() {
+  try {
+    const settings = await prisma.globalSetting.findUnique({
+      where: { id: 1 },
+      select: { backgroundUrl: true },
+    });
+
+    return NextResponse.json({ backgroundUrl: settings?.backgroundUrl ?? null });
+  } catch (error) {
+    console.error("Erro ao obter background", error);
+    return NextResponse.json(
+      { error: "Erro ao obter background" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function PUT(request: NextRequest) {
   const ip = getClientIp(request);
   if (!checkRateLimit(ip)) {
@@ -98,6 +115,7 @@ export async function PUT(request: NextRequest) {
     });
 
     revalidatePath("/");
+    revalidatePath("/sobre-nos");
     return NextResponse.json({ backgroundUrl });
   } catch (error) {
     console.error("Erro ao atualizar background", error);

--- a/app/sobre-nos/page.tsx
+++ b/app/sobre-nos/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Plane,
   Sparkles,
@@ -27,6 +27,11 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
+
+const FALLBACK_HERO_IMAGES = [
+  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1920&auto=format&fit=crop",
+  "https://images.unsplash.com/photo-1516483638261-f4dbaf036963?q=80&w=1920&auto=format&fit=crop",
+];
 
 // --- Helpers de animação simples ---
 function useInView<T extends HTMLElement>(
@@ -88,14 +93,59 @@ function Badge({ children }: { children: React.ReactNode }) {
 }
 
 export default function AboutPage() {
-  // Mock hero images (opcional): use sua marca/imagem se quiser
-  const heroImages = useMemo(
-    () => [
-      "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1920&auto=format&fit=crop",
-      "https://images.unsplash.com/photo-1516483638261-f4dbaf036963?q=80&w=1920&auto=format&fit=crop",
-    ],
-    []
-  );
+  const [heroImages, setHeroImages] = useState<string[]>(FALLBACK_HERO_IMAGES);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadBackground = async () => {
+      try {
+        const response = await fetch("/api/background", { cache: "no-store" });
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as { backgroundUrl?: unknown };
+        if (!isMounted) {
+          return;
+        }
+
+        const backgroundUrl =
+          typeof data.backgroundUrl === "string" && data.backgroundUrl.trim().length > 0
+            ? data.backgroundUrl
+            : null;
+
+        if (!backgroundUrl) {
+          return;
+        }
+
+        setHeroImages((current) => {
+          if (current[0] === backgroundUrl) {
+            return current;
+          }
+
+          const dedupedFallback = FALLBACK_HERO_IMAGES.filter(
+            (image) => image !== backgroundUrl,
+          );
+          const next = [backgroundUrl, ...dedupedFallback];
+
+          if (next.length === current.length && next.every((value, index) => value === current[index])) {
+            return current;
+          }
+
+          return next;
+        });
+      } catch (error) {
+        console.error("Erro ao carregar background", error);
+      }
+    };
+
+    void loadBackground();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <main className="min-h-dvh bg-gradient-to-br from-blue-50 via-white to-cyan-50 text-slate-900">


### PR DESCRIPTION
## Summary
- add a GET handler for `/api/background` and revalidate carousel routes after updates
- load the global background in the about page hero so carousel pages stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27cdc99488333ac00055f50418338