### PR TITLE
feat: manage background gallery

### DIFF
--- a/app/api/background/gallery/[id]/route.ts
+++ b/app/api/background/gallery/[id]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+
+const updateSchema = z.object({
+  url: z
+    .string()
+    .url("Informe uma URL válida")
+    .refine((value) => value.startsWith("https://"), "Use uma URL com HTTPS")
+    .optional(),
+  title: z
+    .string()
+    .trim()
+    .min(1, "Informe um título")
+    .max(120, "O título deve ter até 120 caracteres")
+    .nullable()
+    .optional(),
+  groupKey: z
+    .string()
+    .trim()
+    .min(1, "Informe um grupo")
+    .max(80, "O grupo deve ter até 80 caracteres")
+    .nullable()
+    .optional(),
+  isVisible: z.boolean().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const id = Number(params.id);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return NextResponse.json({ error: "Identificador inválido" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = updateSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues.at(0)?.message ?? "Dados inválidos";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    const exists = await prisma.backgroundImage.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+
+    if (!exists) {
+      return NextResponse.json({ error: "Imagem não encontrada" }, { status: 404 });
+    }
+
+    const data = parsed.data;
+
+    const updated = await prisma.backgroundImage.update({
+      where: { id },
+      data: {
+        url: data.url,
+        title: data.title === undefined ? undefined : data.title,
+        groupKey: data.groupKey === undefined ? undefined : data.groupKey,
+        isVisible: data.isVisible,
+      },
+    });
+
+    if (data.isVisible === false) {
+      await prisma.globalSetting.updateMany({
+        where: { backgroundImageId: id },
+        data: { backgroundImageId: null, backgroundMode: "ALL" },
+      });
+    }
+
+    return NextResponse.json({ image: updated });
+  } catch (error) {
+    console.error("Erro ao atualizar imagem de background", error);
+    return NextResponse.json({ error: "Erro ao atualizar imagem" }, { status: 500 });
+  }
+}

--- a/app/api/background/gallery/route.ts
+++ b/app/api/background/gallery/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const images = await prisma.backgroundImage.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json({ images });
+  } catch (error) {
+    console.error("Erro ao listar backgrounds", error);
+    return NextResponse.json({ error: "Erro ao listar backgrounds" }, { status: 500 });
+  }
+}

--- a/app/api/background/route.ts
+++ b/app/api/background/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
+import type { Prisma } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
 import { DropboxUploadError, storeBackgroundImage } from "@/lib/storage";
 import { assertImage, sanitizeExt } from "@/lib/file";
@@ -49,16 +51,102 @@ const urlSchema = z.object({
     .string()
     .url("Informe uma URL válida")
     .refine((value) => value.startsWith("https://"), "Use uma URL com HTTPS"),
+  title: z
+    .string()
+    .trim()
+    .min(1, "Informe um título")
+    .max(120, "O título deve ter até 120 caracteres")
+    .optional(),
+  groupKey: z
+    .string()
+    .trim()
+    .min(1, "Informe um grupo")
+    .max(80, "O grupo deve ter até 80 caracteres")
+    .optional(),
 });
+
+const modeSchema = z.object({
+  mode: z.enum(["ALL", "GROUP", "SINGLE"]).optional(),
+  imageId: z
+    .number({ coerce: true })
+    .int("Selecione uma imagem válida")
+    .positive("Selecione uma imagem válida")
+    .nullable()
+    .optional(),
+  group: z
+    .string()
+    .trim()
+    .min(1, "Informe um grupo")
+    .max(80, "O grupo deve ter até 80 caracteres")
+    .nullable()
+    .optional(),
+});
+
+type BackgroundMode = "ALL" | "GROUP" | "SINGLE";
+
+async function resolveSelectedBackgrounds({
+  backgroundMode,
+  backgroundGroup,
+  backgroundImageId,
+}: {
+  backgroundMode: BackgroundMode;
+  backgroundGroup: string | null;
+  backgroundImageId: number | null;
+}) {
+  if (backgroundMode === "SINGLE" && backgroundImageId) {
+    const image = await prisma.backgroundImage.findUnique({
+      where: { id: backgroundImageId },
+    });
+    return image ? [image] : [];
+  }
+
+  if (backgroundMode === "GROUP") {
+    if (!backgroundGroup) {
+      return [];
+    }
+
+    return prisma.backgroundImage.findMany({
+      where: {
+        isVisible: true,
+        groupKey: backgroundGroup,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  return prisma.backgroundImage.findMany({
+    where: { isVisible: true },
+    orderBy: { createdAt: "desc" },
+    take: 20,
+  });
+}
 
 export async function GET() {
   try {
     const settings = await prisma.globalSetting.findUnique({
       where: { id: 1 },
-      select: { backgroundUrl: true },
+      select: {
+        backgroundUrl: true,
+        backgroundMode: true,
+        backgroundGroup: true,
+        backgroundImageId: true,
+      },
     });
 
-    return NextResponse.json({ backgroundUrl: settings?.backgroundUrl ?? null });
+    const mode = settings?.backgroundMode ?? "ALL";
+    const selectedBackgrounds = await resolveSelectedBackgrounds({
+      backgroundMode: mode,
+      backgroundGroup: settings?.backgroundGroup ?? null,
+      backgroundImageId: settings?.backgroundImageId ?? null,
+    });
+
+    return NextResponse.json({
+      backgroundUrl: settings?.backgroundUrl ?? null,
+      mode,
+      group: settings?.backgroundGroup ?? null,
+      imageId: settings?.backgroundImageId ?? null,
+      selectedBackgrounds,
+    });
   } catch (error) {
     console.error("Erro ao obter background", error);
     return NextResponse.json(
@@ -76,6 +164,8 @@ export async function PUT(request: NextRequest) {
 
   const contentType = request.headers.get("content-type") ?? "";
   let backgroundUrl: string;
+  let title: string | undefined;
+  let groupKey: string | undefined;
 
   try {
     if (contentType.includes("application/json")) {
@@ -86,6 +176,8 @@ export async function PUT(request: NextRequest) {
         return NextResponse.json({ error: message }, { status: 400 });
       }
       backgroundUrl = parsed.data.url;
+      title = parsed.data.title;
+      groupKey = parsed.data.groupKey;
     } else if (contentType.includes("multipart/form-data")) {
       const formData = await request.formData();
       const file = formData.get("file");
@@ -108,10 +200,18 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "Tipo de conteúdo não suportado" }, { status: 400 });
     }
 
+    const background = await prisma.backgroundImage.create({
+      data: {
+        url: backgroundUrl,
+        title,
+        groupKey,
+      },
+    });
+
     await prisma.globalSetting.upsert({
       where: { id: 1 },
-      update: { backgroundUrl },
-      create: { id: 1, backgroundUrl },
+      update: { backgroundUrl, backgroundImageId: background.id },
+      create: { id: 1, backgroundUrl, backgroundImageId: background.id },
     });
 
     revalidatePath("/");
@@ -138,5 +238,128 @@ export async function PUT(request: NextRequest) {
     }
 
     return NextResponse.json({ error: "Erro ao atualizar background" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+  const parsed = modeSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues.at(0)?.message ?? "Dados inválidos";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const { mode, imageId, group } = parsed.data;
+
+  try {
+    if (!mode && group === undefined && imageId === undefined) {
+      return NextResponse.json({ error: "Nada para atualizar" }, { status: 400 });
+    }
+
+    let modeToSet: BackgroundMode | undefined;
+    let groupToSet: string | null | undefined;
+    let connectImageId: number | null | undefined;
+
+    if (mode === "SINGLE") {
+      if (!imageId) {
+        return NextResponse.json(
+          { error: "Selecione uma imagem para exibir individualmente" },
+          { status: 400 },
+        );
+      }
+
+      const image = await prisma.backgroundImage.findUnique({
+        where: { id: imageId },
+        select: { id: true },
+      });
+
+      if (!image) {
+        return NextResponse.json({ error: "Imagem não encontrada" }, { status: 404 });
+      }
+
+      modeToSet = "SINGLE";
+      groupToSet = null;
+      connectImageId = image.id;
+    } else if (mode === "GROUP") {
+      if (!group) {
+        return NextResponse.json({ error: "Informe o grupo que deseja exibir" }, { status: 400 });
+      }
+
+      modeToSet = "GROUP";
+      groupToSet = group;
+      connectImageId = null;
+    } else if (mode === "ALL") {
+      modeToSet = "ALL";
+      groupToSet = null;
+      connectImageId = null;
+    } else {
+      if (typeof imageId === "number") {
+        const image = await prisma.backgroundImage.findUnique({
+          where: { id: imageId },
+          select: { id: true },
+        });
+        if (!image) {
+          return NextResponse.json({ error: "Imagem não encontrada" }, { status: 404 });
+        }
+        connectImageId = image.id;
+      } else if (imageId === null) {
+        connectImageId = null;
+      }
+
+      if (group !== undefined) {
+        groupToSet = group ?? null;
+      }
+    }
+
+    if (mode && modeToSet === undefined) {
+      modeToSet = mode;
+    }
+
+    const updateData: Prisma.GlobalSettingUpdateInput = {};
+
+    if (modeToSet !== undefined) {
+      updateData.backgroundMode = modeToSet;
+    }
+
+    if (groupToSet !== undefined) {
+      updateData.backgroundGroup = groupToSet;
+    }
+
+    if (connectImageId !== undefined) {
+      updateData.backgroundImage =
+        connectImageId === null
+          ? { disconnect: true }
+          : { connect: { id: connectImageId } };
+    }
+
+    const existing = await prisma.globalSetting.findUnique({ where: { id: 1 } });
+
+    if (existing) {
+      await prisma.globalSetting.update({
+        where: { id: 1 },
+        data: updateData,
+      });
+    } else {
+      const createData: Prisma.GlobalSettingCreateInput = {
+        id: 1,
+        backgroundMode: modeToSet ?? mode ?? "ALL",
+        backgroundGroup: groupToSet ?? null,
+      };
+
+      if (typeof connectImageId === "number") {
+        createData.backgroundImage = { connect: { id: connectImageId } };
+      }
+
+      await prisma.globalSetting.create({ data: createData });
+    }
+
+    revalidatePath("/");
+    revalidatePath("/sobre-nos");
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Erro ao atualizar modo do background", error);
+    return NextResponse.json({ error: "Erro ao atualizar modo" }, { status: 500 });
   }
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { ChangeBackground } from "@/components/ChangeBackground";
+import { BackgroundGalleryManager } from "@/components/BackgroundGalleryManager";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -151,6 +152,22 @@ export default async function DashboardPage() {
             {/* Form reutilizável que permite alterar a imagem de fundo global. */}
             <ChangeBackground isAuthenticated />
           </div>
+        </div>
+
+        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-2xl backdrop-blur-xl transition-all duration-500 sm:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <div className="grid h-12 w-12 place-items-center rounded-2xl border border-white/30 bg-gradient-to-br from-blue-50 to-purple-50 shadow">
+              <Wand2 className="h-6 w-6 text-purple-700" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-slate-900">Gerenciar fotos do background</h2>
+              <p className="text-sm text-slate-600">
+                Edite imagens existentes, organize por grupos e escolha quais ficam visíveis no site.
+              </p>
+            </div>
+          </div>
+
+          <BackgroundGalleryManager />
         </div>
       </section>
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,12 +14,32 @@ export default async function HomePage() {
 
   // 1) Background "global" (igual, sem mexer no backend)
   let backgroundUrl: string | null = null;
+  let backgroundMode: "ALL" | "GROUP" | "SINGLE" = "ALL";
+  let backgroundGroup: string | null = null;
+  let backgroundImageId: number | null = null;
   try {
     const settings = await prisma.globalSetting.findUnique({
       where: { id: 1 },
-      select: { backgroundUrl: true },
+      select: {
+        backgroundUrl: true,
+        backgroundMode: true,
+        backgroundGroup: true,
+        backgroundImageId: true,
+        backgroundImage: { select: { url: true, isVisible: true } },
+      },
     });
     backgroundUrl = settings?.backgroundUrl ?? null;
+    backgroundMode = settings?.backgroundMode ?? "ALL";
+    backgroundGroup = settings?.backgroundGroup ?? null;
+    backgroundImageId = settings?.backgroundImageId ?? null;
+
+    if (
+      backgroundMode === "SINGLE" &&
+      settings?.backgroundImage &&
+      settings.backgroundImage.isVisible
+    ) {
+      backgroundUrl = settings.backgroundImage.url;
+    }
   } catch {
     backgroundUrl = null;
   }
@@ -38,7 +58,51 @@ export default async function HomePage() {
 
   // 3) Slides do hero (igual, só organizei a leitura)
   const heroImages: string[] = [];
-  if (backgroundUrl) heroImages.push(backgroundUrl);
+
+  try {
+    if (backgroundMode === "SINGLE" && backgroundImageId) {
+      const image = await prisma.backgroundImage.findUnique({
+        where: { id: backgroundImageId },
+        select: { url: true, isVisible: true },
+      });
+
+      if (image?.isVisible && image.url) {
+        heroImages.push(image.url);
+      } else if (backgroundUrl) {
+        heroImages.push(backgroundUrl);
+      }
+    } else if (backgroundMode === "GROUP" && backgroundGroup) {
+      const images = await prisma.backgroundImage.findMany({
+        where: { isVisible: true, groupKey: backgroundGroup },
+        orderBy: { createdAt: "desc" },
+        take: 10,
+      });
+
+      if (images.length) {
+        heroImages.push(...images.map((image) => image.url));
+      } else if (backgroundUrl) {
+        heroImages.push(backgroundUrl);
+      }
+    } else {
+      const images = await prisma.backgroundImage.findMany({
+        where: { isVisible: true },
+        orderBy: { createdAt: "desc" },
+        take: 10,
+      });
+
+      if (images.length) {
+        heroImages.push(...images.map((image) => image.url));
+      }
+    }
+  } catch {
+    if (backgroundUrl) {
+      heroImages.push(backgroundUrl);
+    }
+  }
+
+  if (!heroImages.length && backgroundUrl) {
+    heroImages.push(backgroundUrl);
+  }
 
   for (const destination of destinations) {
     const rec = destination as Record<string, unknown>;

--- a/app/sobre-nos/page.tsx
+++ b/app/sobre-nos/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
+import type { BackgroundApiResponse } from "@/types/background";
 
 const FALLBACK_HERO_IMAGES = [
   "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1920&auto=format&fit=crop",
@@ -105,29 +106,37 @@ export default function AboutPage() {
           return;
         }
 
-        const data = (await response.json()) as { backgroundUrl?: unknown };
+        const data = (await response.json()) as Partial<BackgroundApiResponse>;
         if (!isMounted) {
           return;
         }
 
-        const backgroundUrl =
+        const selectedFromApi = Array.isArray(data.selectedBackgrounds)
+          ? data.selectedBackgrounds
+              .map((item) => (typeof item?.url === "string" ? item.url : null))
+              .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+          : [];
+
+        const fallbackBackground =
           typeof data.backgroundUrl === "string" && data.backgroundUrl.trim().length > 0
             ? data.backgroundUrl
             : null;
 
-        if (!backgroundUrl) {
+        const orderedBackgrounds = selectedFromApi.length
+          ? selectedFromApi
+          : fallbackBackground
+            ? [fallbackBackground]
+            : [];
+
+        if (!orderedBackgrounds.length) {
           return;
         }
 
         setHeroImages((current) => {
-          if (current[0] === backgroundUrl) {
-            return current;
-          }
-
           const dedupedFallback = FALLBACK_HERO_IMAGES.filter(
-            (image) => image !== backgroundUrl,
+            (image) => !orderedBackgrounds.includes(image),
           );
-          const next = [backgroundUrl, ...dedupedFallback];
+          const next = [...orderedBackgrounds, ...dedupedFallback];
 
           if (next.length === current.length && next.every((value, index) => value === current[index])) {
             return current;

--- a/components/BackgroundGalleryManager.tsx
+++ b/components/BackgroundGalleryManager.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import Image from "next/image";
+import { Eye, EyeOff, Loader2, Save, UploadCloud } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { BackgroundApiResponse, BackgroundImageItem, BackgroundMode } from "@/types/background";
+
+type BackgroundWithDraft = BackgroundImageItem & {
+  draftTitle: string;
+  draftGroup: string;
+  draftUrl: string;
+  isSaving: boolean;
+  error?: string | null;
+  success?: string | null;
+};
+
+export function BackgroundGalleryManager() {
+  const [mode, setMode] = useState<BackgroundMode>("ALL");
+  const [group, setGroup] = useState("");
+  const [imageId, setImageId] = useState<number | null>(null);
+  const [backgrounds, setBackgrounds] = useState<BackgroundWithDraft[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isModePending, startModeTransition] = useTransition();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [settingsResponse, galleryResponse] = await Promise.all([
+          fetch("/api/background", { cache: "no-store" }),
+          fetch("/api/background/gallery", { cache: "no-store" }),
+        ]);
+
+        if (!settingsResponse.ok) {
+          throw new Error("Não foi possível carregar as configurações");
+        }
+
+        if (!galleryResponse.ok) {
+          throw new Error("Não foi possível carregar a galeria");
+        }
+
+        const settings = (await settingsResponse.json()) as BackgroundApiResponse;
+        const gallery = (await galleryResponse.json()) as { images?: BackgroundImageItem[] };
+
+        setMode(settings.mode ?? "ALL");
+        setGroup(settings.group ?? "");
+        setImageId(settings.imageId ?? null);
+
+        const items = Array.isArray(gallery.images) ? gallery.images : [];
+        setBackgrounds(
+          items.map((item) => ({
+            ...item,
+            draftTitle: item.title ?? "",
+            draftGroup: item.groupKey ?? "",
+            draftUrl: item.url,
+            isSaving: false,
+            error: null,
+            success: null,
+          })),
+        );
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : "Erro desconhecido");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+  }, []);
+
+  const groups = useMemo(() => {
+    const set = new Set<string>();
+    backgrounds.forEach((item) => {
+      if (item.groupKey) {
+        set.add(item.groupKey);
+      }
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [backgrounds]);
+
+  const selectedIds = useMemo(() => {
+    if (mode === "SINGLE" && imageId) {
+      return new Set([imageId]);
+    }
+    if (mode === "GROUP" && group.trim()) {
+      return new Set(
+        backgrounds.filter((item) => item.groupKey === group.trim()).map((item) => item.id),
+      );
+    }
+    return new Set(backgrounds.filter((item) => item.isVisible).map((item) => item.id));
+  }, [backgrounds, mode, imageId, group]);
+
+  const updateDraft = (id: number, field: "draftTitle" | "draftGroup" | "draftUrl", value: string) => {
+    setBackgrounds((current) =>
+      current.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              [field]: value,
+              error: null,
+              success: null,
+            }
+          : item,
+      ),
+    );
+  };
+
+  const syncBackground = (updated: BackgroundImageItem) => {
+    setBackgrounds((current) =>
+      current.map((item) =>
+        item.id === updated.id
+          ? {
+              ...item,
+              ...updated,
+              draftTitle: updated.title ?? "",
+              draftGroup: updated.groupKey ?? "",
+              draftUrl: updated.url,
+              isSaving: false,
+              error: null,
+              success: "Atualizado com sucesso!",
+            }
+          : item,
+      ),
+    );
+  };
+
+  const handleSave = async (id: number) => {
+    const background = backgrounds.find((item) => item.id === id);
+    if (!background) return;
+
+    const payload: Record<string, unknown> = {};
+    const trimmedTitle = background.draftTitle.trim();
+    const trimmedGroup = background.draftGroup.trim();
+    const trimmedUrl = background.draftUrl.trim();
+
+    if (trimmedUrl !== background.url) {
+      payload.url = trimmedUrl;
+    }
+
+    if ((background.title ?? "") !== trimmedTitle) {
+      payload.title = trimmedTitle.length ? trimmedTitle : null;
+    }
+
+    if ((background.groupKey ?? "") !== trimmedGroup) {
+      payload.groupKey = trimmedGroup.length ? trimmedGroup : null;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      setBackgrounds((current) =>
+        current.map((item) =>
+          item.id === id
+            ? { ...item, success: "Nada para atualizar", error: null }
+            : item,
+        ),
+      );
+      return;
+    }
+
+    setBackgrounds((current) =>
+      current.map((item) =>
+        item.id === id ? { ...item, isSaving: true, error: null, success: null } : item,
+      ),
+    );
+
+    try {
+      const response = await fetch(`/api/background/gallery/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = (await response.json().catch(() => ({}))) as { image?: BackgroundImageItem; error?: string };
+
+      if (!response.ok || !data.image) {
+        throw new Error(data.error ?? "Não foi possível atualizar a imagem");
+      }
+
+      syncBackground(data.image);
+      setFeedback("Imagem atualizada!");
+    } catch (err) {
+      setBackgrounds((current) =>
+        current.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                isSaving: false,
+                error: err instanceof Error ? err.message : "Erro inesperado",
+              }
+            : item,
+        ),
+      );
+    }
+  };
+
+  const handleToggleVisibility = async (id: number, nextVisible: boolean) => {
+    setBackgrounds((current) =>
+      current.map((item) =>
+        item.id === id
+          ? { ...item, isSaving: true, error: null, success: null }
+          : item,
+      ),
+    );
+
+    try {
+      const response = await fetch(`/api/background/gallery/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isVisible: nextVisible }),
+      });
+      const data = (await response.json().catch(() => ({}))) as { image?: BackgroundImageItem; error?: string };
+
+      if (!response.ok || !data.image) {
+        throw new Error(data.error ?? "Não foi possível atualizar a visibilidade");
+      }
+
+      syncBackground(data.image);
+      setFeedback(nextVisible ? "Imagem exibida" : "Imagem ocultada");
+    } catch (err) {
+      setBackgrounds((current) =>
+        current.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                isSaving: false,
+                error: err instanceof Error ? err.message : "Erro inesperado",
+              }
+            : item,
+        ),
+      );
+    }
+  };
+
+  const handleModeSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+    setError(null);
+
+    const payload: Record<string, unknown> = { mode };
+
+    if (mode === "GROUP") {
+      if (!group.trim()) {
+        setError("Informe um grupo para exibir");
+        return;
+      }
+      payload.group = group.trim();
+    }
+
+    if (mode === "SINGLE") {
+      if (!imageId) {
+        setError("Selecione uma imagem");
+        return;
+      }
+      payload.imageId = imageId;
+    }
+
+    startModeTransition(async () => {
+      try {
+        const response = await fetch("/api/background", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+
+        if (!response.ok) {
+          throw new Error(data.error ?? "Não foi possível atualizar o modo");
+        }
+
+        setFeedback("Modo de exibição atualizado");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Erro inesperado");
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-slate-600">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Carregando galeria de backgrounds...
+      </div>
+    );
+  }
+
+  if (error && !backgrounds.length) {
+    return <p className="text-sm text-red-600">{error}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-white/20 bg-white/70 p-5 shadow-sm backdrop-blur">
+        <form onSubmit={handleModeSubmit} className="space-y-4">
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Modo de exibição</p>
+            <p className="text-xs text-slate-600">
+              Defina se o site utiliza todas as imagens visíveis, apenas um grupo ou somente uma foto.
+            </p>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-3">
+            {(
+              [
+                { value: "ALL", label: "Todas as visíveis" },
+                { value: "GROUP", label: "Grupo específico" },
+                { value: "SINGLE", label: "Uma foto" },
+              ] satisfies { value: BackgroundMode; label: string }[]
+            ).map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  "flex cursor-pointer flex-col rounded-xl border px-3 py-3 text-sm font-medium transition",
+                  mode === option.value
+                    ? "border-blue-500 bg-blue-50 text-blue-700"
+                    : "border-slate-200 bg-white text-slate-700 hover:border-blue-300",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="mode"
+                  value={option.value}
+                  checked={mode === option.value}
+                  onChange={() => setMode(option.value)}
+                  className="sr-only"
+                />
+                {option.label}
+              </label>
+            ))}
+          </div>
+
+          {mode === "GROUP" && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-slate-600" htmlFor="background-group">
+                Grupo de imagens
+              </label>
+              <input
+                id="background-group"
+                list="background-group-suggestions"
+                value={group}
+                onChange={(event) => setGroup(event.currentTarget.value)}
+                placeholder="Ex.: principal, promoções, verão"
+                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+              <datalist id="background-group-suggestions">
+                {groups.map((item) => (
+                  <option key={item} value={item} />
+                ))}
+              </datalist>
+            </div>
+          )}
+
+          {mode === "SINGLE" && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-slate-600" htmlFor="background-single">
+                Escolha a imagem
+              </label>
+              <select
+                id="background-single"
+                value={imageId ?? ""}
+                onChange={(event) => setImageId(event.currentTarget.value ? Number(event.currentTarget.value) : null)}
+                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                <option value="">Selecione uma imagem</option>
+                {backgrounds.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.title?.length ? item.title : `Imagem #${item.id}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {feedback && <p className="text-sm text-green-600">{feedback}</p>}
+
+          <button
+            type="submit"
+            disabled={isModePending}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isModePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            Salvar modo de exibição
+          </button>
+        </form>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Fotos cadastradas</h3>
+          <p className="text-xs text-slate-600">
+            Edite as informações, atribua grupos e controle a visibilidade das imagens disponíveis no background.
+          </p>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {backgrounds.map((item) => {
+            const isSelected = selectedIds.has(item.id);
+
+            return (
+              <div
+                key={item.id}
+                className={cn(
+                  "relative overflow-hidden rounded-2xl border bg-white shadow-sm transition",
+                  isSelected ? "border-blue-400 ring-2 ring-blue-200" : "border-slate-200",
+                )}
+              >
+                <div className="relative h-40 w-full">
+                  <Image
+                    src={item.draftUrl || item.url}
+                    alt={item.title ?? `Imagem ${item.id}`}
+                    fill
+                    className="object-cover"
+                  />
+                  {!item.isVisible && (
+                    <span className="absolute inset-x-0 top-2 mx-auto w-max rounded-full bg-black/60 px-3 py-1 text-xs font-medium text-white">
+                      Oculta
+                    </span>
+                  )}
+                  {isSelected && (
+                    <span className="absolute inset-x-0 bottom-2 mx-auto w-max rounded-full bg-blue-600/90 px-3 py-1 text-xs font-semibold text-white shadow">
+                      Em uso
+                    </span>
+                  )}
+                </div>
+
+                <div className="space-y-3 p-4">
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-slate-600" htmlFor={`title-${item.id}`}>
+                      Título
+                    </label>
+                    <input
+                      id={`title-${item.id}`}
+                      value={item.draftTitle}
+                      onChange={(event) => updateDraft(item.id, "draftTitle", event.currentTarget.value)}
+                      placeholder="Descrição da imagem"
+                      className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    />
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-slate-600" htmlFor={`group-${item.id}`}>
+                      Grupo
+                    </label>
+                    <input
+                      id={`group-${item.id}`}
+                      value={item.draftGroup}
+                      onChange={(event) => updateDraft(item.id, "draftGroup", event.currentTarget.value)}
+                      placeholder="Ex.: principal, promoções"
+                      className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    />
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-slate-600" htmlFor={`url-${item.id}`}>
+                      URL
+                    </label>
+                    <input
+                      id={`url-${item.id}`}
+                      value={item.draftUrl}
+                      onChange={(event) => updateDraft(item.id, "draftUrl", event.currentTarget.value)}
+                      className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    />
+                  </div>
+
+                  {item.error && <p className="text-xs text-red-600">{item.error}</p>}
+                  {item.success && <p className="text-xs text-green-600">{item.success}</p>}
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleSave(item.id)}
+                      disabled={item.isSaving}
+                      className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {item.isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                      Salvar alterações
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleVisibility(item.id, !item.isVisible)}
+                      disabled={item.isSaving}
+                      className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {item.isSaving ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : item.isVisible ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                      {item.isVisible ? "Ocultar" : "Exibir"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {feedback && backgrounds.length > 0 && (
+          <div className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-700">
+            <UploadCloud className="h-4 w-4" />
+            {feedback}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/prisma/migrations/20251004180000_background_gallery/migration.sql
+++ b/prisma/migrations/20251004180000_background_gallery/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "BackgroundDisplayMode" AS ENUM ('ALL', 'GROUP', 'SINGLE');
+
+-- CreateTable
+CREATE TABLE "BackgroundImage" (
+    "id" SERIAL NOT NULL,
+    "url" TEXT NOT NULL,
+    "title" TEXT,
+    "groupKey" TEXT,
+    "isVisible" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BackgroundImage_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "GlobalSetting"
+    ADD COLUMN "backgroundGroup" TEXT,
+    ADD COLUMN "backgroundImageId" INTEGER,
+    ADD COLUMN "backgroundMode" "BackgroundDisplayMode" NOT NULL DEFAULT 'ALL';
+
+-- AddForeignKey
+ALTER TABLE "GlobalSetting"
+    ADD CONSTRAINT "GlobalSetting_backgroundImageId_fkey"
+    FOREIGN KEY ("backgroundImageId") REFERENCES "BackgroundImage"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Trigger to keep updatedAt in sync
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updatedAt" = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER set_background_image_updated_at
+BEFORE UPDATE ON "BackgroundImage"
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,9 +17,32 @@ model User {
   destinations Destination[]
 }
 
+enum BackgroundDisplayMode {
+  ALL
+  GROUP
+  SINGLE
+}
+
 model GlobalSetting {
-  id            Int    @id
-  backgroundUrl String?
+  id                Int                     @id
+  backgroundUrl     String?
+  backgroundMode    BackgroundDisplayMode   @default(ALL)
+  backgroundGroup   String?
+  backgroundImageId Int?
+
+  backgroundImage BackgroundImage? @relation(fields: [backgroundImageId], references: [id])
+}
+
+model BackgroundImage {
+  id        Int      @id @default(autoincrement())
+  url       String
+  title     String?
+  groupKey  String?
+  isVisible Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  selectedIn GlobalSetting[]
 }
 
 model Destination {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -20,10 +20,59 @@ async function main() {
     select: { id: true, username: true },
   });
 
+  let primaryBackground = await prisma.backgroundImage.findFirst({
+    orderBy: { id: "asc" },
+  });
+
+  if (!primaryBackground) {
+    await prisma.backgroundImage.createMany({
+      data: [
+        {
+          url: avatarUrl,
+          title: "Pôr do sol tropical",
+          groupKey: "principal",
+        },
+        {
+          url: "https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?w=1600",
+          title: "Montanhas nevadas",
+          groupKey: "aventura",
+        },
+        {
+          url: "https://images.unsplash.com/photo-1521292270410-a8c07b1ec3ba?w=1600",
+          title: "Cidade iluminada",
+          groupKey: "urbano",
+        },
+      ],
+      skipDuplicates: true,
+    });
+    primaryBackground = await prisma.backgroundImage.findFirst({
+      orderBy: { id: "asc" },
+    });
+  }
+
+  if (!primaryBackground) {
+    primaryBackground = await prisma.backgroundImage.create({
+      data: {
+        url: avatarUrl,
+        title: "Paisagem padrão",
+        groupKey: "principal",
+      },
+    });
+  }
+
   await prisma.globalSetting.upsert({
     where: { id: 1 },
-    update: { backgroundUrl: avatarUrl },
-    create: { id: 1, backgroundUrl: avatarUrl },
+    update: {
+      backgroundUrl: primaryBackground.url,
+      backgroundMode: "SINGLE",
+      backgroundImage: { connect: { id: primaryBackground.id } },
+    },
+    create: {
+      id: 1,
+      backgroundUrl: primaryBackground.url,
+      backgroundMode: "SINGLE",
+      backgroundImage: { connect: { id: primaryBackground.id } },
+    },
   });
 
   const destinationName = "Ilha dos Sonhos";

--- a/types/background.ts
+++ b/types/background.ts
@@ -1,0 +1,19 @@
+export type BackgroundMode = "ALL" | "GROUP" | "SINGLE";
+
+export type BackgroundImageItem = {
+  id: number;
+  url: string;
+  title: string | null;
+  groupKey: string | null;
+  isVisible: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BackgroundApiResponse = {
+  backgroundUrl: string | null;
+  mode: BackgroundMode;
+  group: string | null;
+  imageId: number | null;
+  selectedBackgrounds: BackgroundImageItem[];
+};


### PR DESCRIPTION
## Summary
- add Prisma structures for reusable background images and display modes, plus new gallery endpoints
- expose a dashboard manager UI to edit background metadata, visibility, and selection mode
- update homepage and about page background resolution logic to respect the selected mode and seed default gallery images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e281b37a608333bccb0ce1ce0fac9b