### PR TITLE
Fix background gallery PATCH handler and keep server APIs on the Node runtime

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,5 @@
 import { handlers } from "@/lib/auth";
 
+export const runtime = "nodejs";
+
 export const { GET, POST } = handlers;

--- a/app/api/background/gallery/[id]/route.ts
+++ b/app/api/background/gallery/[id]/route.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 
 import { prisma } from "@/lib/prisma";
 
+export const runtime = "nodejs";
+
 const updateSchema = z.object({
   url: z
     .string()
@@ -26,11 +28,10 @@ const updateSchema = z.object({
   isVisible: z.boolean().optional(),
 });
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { id: string } },
-) {
-  const id = Number(params.id);
+export async function PATCH(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const idParam = pathname.split("/").filter(Boolean).at(-1);
+  const id = Number(idParam);
 
   if (!Number.isInteger(id) || id <= 0) {
     return NextResponse.json({ error: "Identificador inválido" }, { status: 400 });

--- a/app/api/background/gallery/route.ts
+++ b/app/api/background/gallery/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 
+export const runtime = "nodejs";
+
 export async function GET() {
   try {
     const images = await prisma.backgroundImage.findMany({

--- a/app/api/background/route.ts
+++ b/app/api/background/route.ts
@@ -8,6 +8,8 @@ import { prisma } from "@/lib/prisma";
 import { DropboxUploadError, storeBackgroundImage } from "@/lib/storage";
 import { assertImage, sanitizeExt } from "@/lib/file";
 
+export const runtime = "nodejs";
+
 const RATE_LIMIT_WINDOW = 10 * 60 * 1000;
 const RATE_LIMIT_MAX = 10;
 const rateLimitMap = new Map<string, { count: number; windowStart: number }>();

--- a/app/api/dev/create-user/route.ts
+++ b/app/api/dev/create-user/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import bcrypt from "bcryptjs";
 
+export const runtime = "nodejs";
+
 export async function POST(request: Request) {
   const { username, password, imageUrl } = await request.json();
 

--- a/app/api/dropbox/exchange/route.ts
+++ b/app/api/dropbox/exchange/route.ts
@@ -1,6 +1,8 @@
 // app/api/dropbox/exchange/route.ts
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 function basicAuth(appKey: string, appSecret: string) {
   return Buffer.from(`${appKey}:${appSecret}`).toString("base64");
 }

--- a/app/api/dropbox/test/route.ts
+++ b/app/api/dropbox/test/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { getDropbox, getDropboxCredentialsStatus } from "@/lib/dropbox";
 
+export const runtime = "nodejs";
+
 interface LogEntry {
   level: "info" | "success" | "warning" | "error";
   message: string;

--- a/app/api/profile/photo/route.ts
+++ b/app/api/profile/photo/route.ts
@@ -6,6 +6,8 @@ import { DropboxUploadError, storeProfileImage } from "@/lib/storage";
 import { UploadLogEntry, UploadErrorDetails } from "@/types/upload";
 import { assertImage, sanitizeExt } from "@/lib/file";
 
+export const runtime = "nodejs";
+
 export async function POST(request: Request) {
   const session = await auth();
 

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { hashPassword } from "@/lib/hash";
 
+export const runtime = "nodejs";
+
 const signupSchema = z.object({
   username: z
     .string()

--- a/lib/hash.ts
+++ b/lib/hash.ts
@@ -1,9 +1,20 @@
-import bcrypt from "bcryptjs";
+type BcryptModule = typeof import("bcryptjs");
+
+let bcryptPromise: Promise<BcryptModule> | undefined;
+
+async function loadBcrypt(): Promise<BcryptModule> {
+  if (!bcryptPromise) {
+    bcryptPromise = import("bcryptjs");
+  }
+  return bcryptPromise;
+}
 
 export async function hashPassword(password: string) {
+  const bcrypt = await loadBcrypt();
   return bcrypt.hash(password, 10);
 }
 
 export async function verifyPassword(password: string, hash: string) {
+  const bcrypt = await loadBcrypt();
   return bcrypt.compare(password, hash);
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,40 @@
 import { NextResponse } from "next/server";
-
-import { auth } from "@/lib/auth";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
 const protectedMatchers = ["/dashboard", "/api/profile", "/usuario"];
 
-export default auth((request) => {
+async function isAuthenticated(request: NextRequest) {
+  try {
+    const token = await getToken({ req: request, secret: process.env.AUTH_SECRET });
+    return Boolean(token?.userId ?? token?.sub);
+  } catch (error) {
+    console.error("Erro ao validar token na middleware", error);
+    return false;
+  }
+}
+
+export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const requiresAuth = protectedMatchers.some((path) => pathname === path || pathname.startsWith(`${path}/`));
+  const requiresAuth = protectedMatchers.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  );
 
   if (!requiresAuth) {
     return NextResponse.next();
   }
 
-  if (request.auth?.user?.id) {
+  if (await isAuthenticated(request)) {
     return NextResponse.next();
   }
 
   const redirectUrl = new URL("/login", request.url);
-  redirectUrl.searchParams.set("callbackUrl", request.nextUrl.pathname + request.nextUrl.search);
+  redirectUrl.searchParams.set(
+    "callbackUrl",
+    request.nextUrl.pathname + request.nextUrl.search,
+  );
   return NextResponse.redirect(redirectUrl);
-});
+}
 
 export const config = {
   matcher: ["/dashboard/:path*", "/api/profile/:path*", "/usuario/:path*"],


### PR DESCRIPTION
## Summary
- fix the background gallery PATCH handler by deriving the id from the request URL and validating it without relying on route params types
- force Prisma/Bcrypt backed API routes and auth handlers to opt into the Node.js runtime and lazy-load bcrypt to avoid Edge runtime build warnings
- replace the middleware auth helper with a JWT-based check that works in the Edge runtime while preserving protected-route redirects

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e28641c1f48333bc50eb8534cae3c7