### PR TITLE
Move destination creation to dashboard and refresh Destinos UI

### DIFF
--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -1,0 +1,135 @@
+"use server";
+
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+import {
+  type DestinationFormState,
+  destinationFormSchema,
+} from "@/lib/destinations";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { assertImage, sanitizeExt } from "@/lib/file";
+import { storeDestinationPhoto } from "@/lib/storage";
+
+export async function createDestination(
+  _prevState: DestinationFormState,
+  formData: FormData
+): Promise<DestinationFormState> {
+  // Garante que apenas usuários autenticados possam cadastrar destinos.
+  const session = await auth();
+  if (!session?.user?.id) {
+    return {
+      status: "error",
+      message: "Você precisa estar autenticado para criar um destino.",
+    };
+  }
+
+  // Normaliza as URLs de fotos informadas manualmente no formulário.
+  const photosRaw = String(formData.get("photos") ?? "");
+  const manualPhotos = photosRaw
+    .split(/\r?\n|,/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  // Separa os arquivos enviados via upload para validação e armazenamento.
+  const photoFiles = formData
+    .getAll("photoFiles")
+    .filter((value): value is File => value instanceof File && value.size > 0);
+
+  const uploadedPhotos: string[] = [];
+  const uploadErrors: string[] = [];
+
+  for (const file of photoFiles) {
+    try {
+      // Valida o tipo do arquivo e encaminha para o storage configurado.
+      assertImage(file);
+      const ext = sanitizeExt(file.type);
+      const arrayBuffer = await file.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const imageUrl = await storeDestinationPhoto(
+        String(session.user.id),
+        ext,
+        buffer,
+        {
+          originalName: file.name,
+        }
+      );
+      uploadedPhotos.push(imageUrl);
+    } catch (error) {
+      console.error("Erro ao enviar foto de destino", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Não foi possível enviar o arquivo.";
+      uploadErrors.push(`${file.name || "Arquivo"}: ${message}`);
+    }
+  }
+
+  if (uploadErrors.length > 0) {
+    return {
+      status: "error",
+      message: "Não foi possível enviar todas as imagens selecionadas.",
+      errors: { photoFiles: uploadErrors },
+    };
+  }
+
+  // Junta e remove duplicidades entre URLs manuais e fotos recém-enviadas.
+  const photos = Array.from(new Set([...manualPhotos, ...uploadedPhotos]));
+
+  // Faz o parse dos campos utilizando o schema do Zod para garantir consistência.
+  const parsed = destinationFormSchema.safeParse({
+    name: formData.get("name"),
+    city: formData.get("city"),
+    description: formData.get("description"),
+    price: formData.get("price"),
+    peopleCount: formData.get("peopleCount"),
+    startDate: formData.get("startDate"),
+    endDate: formData.get("endDate"),
+    rating: formData.get("rating"),
+    photos,
+  });
+
+  if (!parsed.success) {
+    const errors = parsed.error.flatten().fieldErrors;
+    return {
+      status: "error",
+      message: "Revise os campos destacados antes de salvar.",
+      errors,
+    };
+  }
+
+  try {
+    // Persiste o destino no banco, convertendo valores numéricos quando necessário.
+    await prisma.destination.create({
+      data: {
+        name: parsed.data.name,
+        city: parsed.data.city,
+        description: parsed.data.description,
+        price: new Prisma.Decimal(parsed.data.price),
+        peopleCount: parsed.data.peopleCount,
+        startDate: parsed.data.startDate,
+        endDate: parsed.data.endDate,
+        rating: parsed.data.rating,
+        photos: parsed.data.photos,
+        userId: Number(session.user.id),
+      },
+    });
+  } catch (error) {
+    console.error("Erro ao criar destino", error);
+    return {
+      status: "error",
+      message: "Não foi possível criar o destino. Tente novamente mais tarde.",
+    };
+  }
+
+  // Atualiza o cache das páginas que exibem a lista de destinos.
+  revalidatePath("/destinos");
+  revalidatePath("/");
+  revalidatePath("/dashboard");
+
+  return {
+    status: "success",
+    message: "Destino criado com sucesso!",
+  };
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,10 +7,13 @@ import {
   ShieldCheck,
   Wand2,
   Link as LinkIcon,
+  MapPin,
 } from "lucide-react";
 
 import { ChangeBackground } from "@/components/ChangeBackground";
 import { BackgroundGalleryManager } from "@/components/BackgroundGalleryManager";
+import { CreateDestinationForm } from "@/components/destinations/create-destination-form";
+import { createDestination } from "./actions";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -152,6 +155,26 @@ export default async function DashboardPage() {
             {/* Form reutilizável que permite alterar a imagem de fundo global. */}
             <ChangeBackground isAuthenticated />
           </div>
+        </div>
+
+        <div className="group relative mt-6 overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-2xl backdrop-blur-xl transition-all duration-500 sm:p-8">
+          <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-cyan-500/10" />
+          </div>
+
+          <div className="mb-6 flex items-center gap-3">
+            <div className="grid h-12 w-12 place-items-center rounded-2xl border border-white/30 bg-gradient-to-br from-blue-50 to-purple-50 shadow">
+              <MapPin className="h-6 w-6 text-blue-700" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-slate-900">Cadastrar novo destino</h2>
+              <p className="text-sm text-slate-600">
+                Adicione rapidamente experiências à página de destinos sem sair do painel administrativo.
+              </p>
+            </div>
+          </div>
+
+          <CreateDestinationForm action={createDestination} />
         </div>
 
         <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-2xl backdrop-blur-xl transition-all duration-500 sm:p-8">

--- a/app/destinos/page.tsx
+++ b/app/destinos/page.tsx
@@ -1,6 +1,5 @@
-import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
-import { 
+import {
   Plane,
   MapPin,
   Ship,
@@ -15,149 +14,25 @@ import {
   Mail,
   MessageCircle,
   ChevronRight,
-  Compass,
   Waves,
   Mountain,
   Palmtree,
   Building,
-  Camera
+  Camera,
+  Flame,
+  Star,
 } from "lucide-react";
 
-import { CreateDestinationForm } from "@/components/destinations/create-destination-form";
 import { DestinationGrid } from "@/components/destinations/destination-grid";
 import {
-  DestinationFormState,
-  destinationFormSchema,
   type DestinationDeleteState,
   serializeDestination,
   type SerializedDestination,
 } from "@/lib/destinations";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { assertImage, sanitizeExt } from "@/lib/file";
-import { storeDestinationPhoto } from "@/lib/storage";
 
 export const runtime = "nodejs";
-
-// Ação server-side responsável por criar novos destinos a partir do formulário da página.
-async function createDestination(
-  _prevState: DestinationFormState,
-  formData: FormData
-): Promise<DestinationFormState> {
-  "use server";
-
-  // Garante que apenas usuários autenticados possam cadastrar destinos.
-  const session = await auth();
-  if (!session?.user?.id) {
-    return {
-      status: "error",
-      message: "Você precisa estar autenticado para criar um destino.",
-    };
-  }
-
-  // Normaliza as URLs de fotos informadas manualmente no formulário.
-  const photosRaw = String(formData.get("photos") ?? "");
-  const manualPhotos = photosRaw
-    .split(/\r?\n|,/)
-    .map((value) => value.trim())
-    .filter(Boolean);
-
-  // Separa os arquivos enviados via upload para validação e armazenamento.
-  const photoFiles = formData
-    .getAll("photoFiles")
-    .filter((value): value is File => value instanceof File && value.size > 0);
-
-  const uploadedPhotos: string[] = [];
-  const uploadErrors: string[] = [];
-
-  for (const file of photoFiles) {
-    try {
-      // Valida o tipo do arquivo e encaminha para o storage configurado.
-      assertImage(file);
-      const ext = sanitizeExt(file.type);
-      const arrayBuffer = await file.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      const imageUrl = await storeDestinationPhoto(String(session.user.id), ext, buffer, {
-        originalName: file.name,
-      });
-      uploadedPhotos.push(imageUrl);
-    } catch (error) {
-      console.error("Erro ao enviar foto de destino", error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Não foi possível enviar o arquivo.";
-      uploadErrors.push(`${file.name || "Arquivo"}: ${message}`);
-    }
-  }
-
-  if (uploadErrors.length > 0) {
-    return {
-      status: "error",
-      message: "Não foi possível enviar todas as imagens selecionadas.",
-      errors: { photoFiles: uploadErrors },
-    };
-  }
-
-  // Junta e remove duplicidades entre URLs manuais e fotos recém-enviadas.
-  const photos = Array.from(new Set([...manualPhotos, ...uploadedPhotos]));
-
-  // Faz o parse dos campos utilizando o schema do Zod para garantir consistência.
-  const parsed = destinationFormSchema.safeParse({
-    name: formData.get("name"),
-    city: formData.get("city"),
-    description: formData.get("description"),
-    price: formData.get("price"),
-    peopleCount: formData.get("peopleCount"),
-    startDate: formData.get("startDate"),
-    endDate: formData.get("endDate"),
-    rating: formData.get("rating"),
-    photos,
-  });
-
-  if (!parsed.success) {
-    // Retorna os erros de validação para que o formulário mostre mensagens ao usuário.
-    const errors = parsed.error.flatten().fieldErrors;
-    return {
-      status: "error",
-      message: "Revise os campos destacados antes de salvar.",
-      errors,
-    };
-  }
-
-  try {
-    // Persiste o destino no banco, convertendo valores numéricos quando necessário.
-    await prisma.destination.create({
-      data: {
-        name: parsed.data.name,
-        city: parsed.data.city,
-        description: parsed.data.description,
-        price: new Prisma.Decimal(parsed.data.price),
-        peopleCount: parsed.data.peopleCount,
-        startDate: parsed.data.startDate,
-        endDate: parsed.data.endDate,
-        rating: parsed.data.rating,
-        photos: parsed.data.photos,
-        userId: Number(session.user.id),
-      },
-    });
-  } catch (error) {
-    console.error("Erro ao criar destino", error);
-    return {
-      status: "error",
-      message: "Não foi possível criar o destino. Tente novamente mais tarde.",
-    };
-  }
-
-  // Atualiza o cache das páginas que exibem a lista de destinos.
-  revalidatePath("/destinos");
-  revalidatePath("/");
-
-  return {
-    status: "success",
-    message: "Destino criado com sucesso!",
-  };
-}
 
 // Ação server-side responsável por remover destinos cadastrados pelo usuário.
 async function deleteDestination(
@@ -228,9 +103,8 @@ async function deleteDestination(
   };
 }
 
-// Página que lista todos os destinos cadastrados e oferece formulários para criação e exclusão.
+// Página que lista todos os destinos cadastrados e oferece destaque para cada experiência.
 export default async function DestinationsPage() {
-  // Recupera a sessão para saber se o usuário pode gerenciar destinos.
   const session = await auth();
 
   let destinations: SerializedDestination[] = [];
@@ -246,223 +120,272 @@ export default async function DestinationsPage() {
     destinationsError = true;
   }
 
+  const destinationCount = destinations.length;
+  const bestRatedDestination = destinations.reduce<SerializedDestination | null>(
+    (best, current) => {
+      if (!best || current.rating > best.rating) {
+        return current;
+      }
+      return best;
+    },
+    null
+  );
+  const budgetDestination = destinations.reduce<SerializedDestination | null>(
+    (best, current) => {
+      if (!best || current.price < best.price) {
+        return current;
+      }
+      return best;
+    },
+    null
+  );
+  const newestDestination = destinations[0] ?? null;
+
+  const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    minimumFractionDigits: 2,
+  });
+
+  const bestRatingLabel = bestRatedDestination
+    ? bestRatedDestination.rating.toFixed(1)
+    : "—";
+  const budgetPriceLabel = budgetDestination
+    ? currencyFormatter.format(budgetDestination.price)
+    : "—";
+  const newestCityLabel = newestDestination
+    ? newestDestination.city
+    : "Cadastre um novo destino e inspire os viajantes";
+
   return (
-    <main className="relative min-h-screen bg-gradient-to-br from-blue-50 via-white to-cyan-50 overflow-hidden">
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-blue-50 via-white to-cyan-50">
       {/* Elementos decorativos animados de fundo */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-10 w-72 h-72 bg-blue-200 rounded-full blur-3xl opacity-30 animate-pulse"></div>
-        <div className="absolute bottom-40 right-20 w-96 h-96 bg-cyan-200 rounded-full blur-3xl opacity-30 animate-pulse [animation-delay:2s]"></div>
-        <div className="absolute top-1/2 left-1/3 w-80 h-80 bg-teal-200 rounded-full blur-3xl opacity-20 animate-pulse [animation-delay:4s]"></div>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute top-24 left-10 h-72 w-72 animate-pulse rounded-full bg-blue-200 blur-3xl opacity-30"></div>
+        <div className="absolute bottom-40 right-20 h-96 w-96 animate-pulse rounded-full bg-cyan-200 blur-3xl opacity-30 [animation-delay:2s]"></div>
+        <div className="absolute top-1/2 left-1/3 h-80 w-80 animate-pulse rounded-full bg-teal-200 blur-3xl opacity-20 [animation-delay:4s]"></div>
       </div>
 
-      {/* Hero Section */}
-      <section className="relative">
-        <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-          {/* Logo e Header Principal */}
-          <div className="text-center mb-12">
-            <div className="inline-flex items-center gap-3 mb-6">
-              <div className="relative">
-                <Plane className="w-10 h-10 text-blue-600 animate-bounce" />
-                <Sparkles className="w-5 h-5 text-yellow-500 absolute -top-1 -right-1 animate-pulse" />
-              </div>
-              <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent">
-                Evastur
-              </h1>
+      {/* Seção principal de destinos destacados */}
+      <section id="destinos" className="relative z-10">
+        <div className="mx-auto max-w-7xl px-4 pb-12 pt-24 sm:px-6 lg:px-8">
+          <div className="flex flex-col items-center text-center">
+            <div className="inline-flex items-center gap-2 rounded-full border border-blue-200/60 bg-white/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-blue-700 shadow-sm">
+              <Sparkles className="h-4 w-4 animate-spin text-blue-500" style={{ animationDuration: "18s" }} />
+              <span>Destaques exclusivos</span>
             </div>
-            <p className="text-lg md:text-xl text-gray-700 font-semibold mb-2">
-              Transformamos sonhos em viagens inesquecíveis
-            </p>
-            <p className="text-sm md:text-base text-gray-600 max-w-2xl mx-auto">
-              Sua jornada dos sonhos começa aqui! Explore destinos incríveis com os melhores preços e atendimento personalizado.
+            <h1 className="mt-6 text-4xl font-bold text-slate-900 md:text-5xl">
+              Conheça os destinos mais inspiradores da Evastur
+            </h1>
+            <p className="mt-4 max-w-3xl text-base text-slate-600 md:text-lg">
+              Explore experiências cuidadosamente selecionadas para diferentes estilos de viagem. Clique em um card para descobrir detalhes, fotos em alta resolução e dicas especiais da nossa equipe.
             </p>
           </div>
 
-          {/* Cards de Serviços */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-12">
-            {[
-              { icon: Plane, title: "Passagens Aéreas", desc: "Melhores tarifas", color: "from-blue-50 to-blue-100", iconColor: "text-blue-600" },
-              { icon: Luggage, title: "Pacotes Completos", desc: "Tudo incluído", color: "from-purple-50 to-purple-100", iconColor: "text-purple-600" },
-              { icon: Ship, title: "Cruzeiros", desc: "Experiências no mar", color: "from-cyan-50 to-cyan-100", iconColor: "text-cyan-600" },
-              { icon: Globe, title: "Viagens Internacionais", desc: "O mundo é seu", color: "from-green-50 to-green-100", iconColor: "text-green-600" }
-            ].map((service, index) => (
-              <div 
-                key={index}
-                className="group relative bg-white rounded-2xl p-6 shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 cursor-pointer overflow-hidden"
-              >
-                <div className={`absolute inset-0 bg-gradient-to-br ${service.color} opacity-0 group-hover:opacity-100 transition-opacity duration-300`}></div>
-                <div className="relative z-10">
-                  <service.icon className={`w-10 h-10 ${service.iconColor} mb-3 group-hover:scale-110 transition-transform duration-300`} />
-                  <h3 className="font-bold text-gray-800 mb-1">{service.title}</h3>
-                  <p className="text-sm text-gray-600">{service.desc}</p>
-                </div>
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="group flex items-center gap-4 rounded-2xl border border-white/40 bg-white/80 p-5 shadow-xl backdrop-blur transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500/20 to-cyan-500/40 text-blue-700">
+                <MapPin className="h-7 w-7" />
               </div>
+              <div className="text-left">
+                <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+                  Destinos disponíveis
+                </p>
+                <p className="text-3xl font-bold text-slate-900">{destinationCount}</p>
+                <span className="text-sm text-slate-600">experiências aguardando você</span>
+              </div>
+            </div>
+
+            <div className="group flex items-center gap-4 rounded-2xl border border-white/40 bg-white/80 p-5 shadow-xl backdrop-blur transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500/20 to-pink-500/30 text-purple-700">
+                <Star className="h-7 w-7" />
+              </div>
+              <div className="text-left">
+                <p className="text-xs font-semibold uppercase tracking-wide text-purple-600">
+                  Mais bem avaliado
+                </p>
+                <p className="text-3xl font-bold text-slate-900">{bestRatingLabel}</p>
+                <span className="text-sm text-slate-600">
+                  {bestRatedDestination ? bestRatedDestination.name : "Cadastre um destino para inaugurar"}
+                </span>
+              </div>
+            </div>
+
+            <div className="group flex items-center gap-4 rounded-2xl border border-white/40 bg-white/80 p-5 shadow-xl backdrop-blur transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-orange-500/20 to-amber-500/30 text-amber-600">
+                <Flame className="h-7 w-7" />
+              </div>
+              <div className="text-left">
+                <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+                  Oferta do momento
+                </p>
+                <p className="text-3xl font-bold text-slate-900">{budgetPriceLabel}</p>
+                <span className="text-sm text-slate-600">
+                  {budgetDestination ? `no destino ${budgetDestination.name}` : "Novas promoções chegam em breve"}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <p className="mt-6 text-center text-sm font-medium text-slate-600">
+            Atualização mais recente: {newestCityLabel}
+          </p>
+
+          <div className="mt-10 flex flex-wrap justify-center gap-3">
+            {[
+              { icon: Waves, label: "Praias", bg: "from-blue-100/70 to-cyan-100/70", text: "text-blue-600" },
+              { icon: Mountain, label: "Montanhas", bg: "from-emerald-100/70 to-lime-100/70", text: "text-emerald-600" },
+              { icon: Building, label: "Cidades", bg: "from-purple-100/70 to-indigo-100/70", text: "text-purple-600" },
+              { icon: Palmtree, label: "Tropical", bg: "from-orange-100/70 to-amber-100/70", text: "text-amber-600" },
+              { icon: Camera, label: "Aventura", bg: "from-rose-100/70 to-pink-100/70", text: "text-rose-600" },
+            ].map((category) => (
+              <button
+                key={category.label}
+                className={`group inline-flex items-center gap-2 rounded-full border border-white/50 bg-gradient-to-r ${category.bg} px-6 py-3 text-sm font-semibold text-slate-700 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl`}
+              >
+                <category.icon className={`h-5 w-5 ${category.text} transition-transform duration-300 group-hover:scale-110`} />
+                <span>{category.label}</span>
+              </button>
             ))}
           </div>
 
-          {/* Benefícios */}
-          <div className="bg-gradient-to-r from-blue-600 to-cyan-600 rounded-3xl p-8 md:p-12 mb-12 text-white shadow-2xl">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
-              {[
-                { icon: Shield, title: "Segurança Total", desc: "Viaje com tranquilidade e proteção completa" },
-                { icon: TrendingUp, title: "Melhor Preço", desc: "Garantimos as melhores ofertas do mercado" },
-                { icon: Heart, title: "Atendimento VIP", desc: "Suporte 24h com especialistas em viagens" }
-              ].map((benefit, index) => (
-                <div key={index} className="group">
-                  <benefit.icon className="w-12 h-12 mx-auto mb-4 group-hover:scale-110 transition-transform duration-300" />
-                  <h3 className="font-bold text-lg mb-2">{benefit.title}</h3>
-                  <p className="text-blue-100 text-sm">{benefit.desc}</p>
-                </div>
-              ))}
-            </div>
-          </div>
+          <div className="relative mt-12 overflow-hidden rounded-[32px] border border-white/30 bg-white/80 p-8 shadow-[0_30px_60px_-30px_rgba(15,118,190,0.45)] backdrop-blur">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-cyan-500/20"></div>
+            <div className="pointer-events-none absolute -left-24 top-20 h-64 w-64 rounded-full bg-blue-500/20 blur-3xl"></div>
+            <div className="pointer-events-none absolute -right-24 bottom-0 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl"></div>
 
-          {/* CTA Section */}
-          <div className="bg-gradient-to-r from-purple-100 to-pink-100 rounded-3xl p-8 mb-12 relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-40 h-40 bg-yellow-300 rounded-full blur-3xl opacity-30 animate-pulse"></div>
-            <div className="relative z-10 text-center">
-              <Sparkles className="w-12 h-12 text-yellow-500 mx-auto mb-4 animate-spin" style={{ animationDuration: '20s' }} />
-              <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-4">
-                Promoções Imperdíveis!
-              </h2>
-              <p className="text-gray-700 mb-6 max-w-2xl mx-auto">
-                Cadastre-se agora e receba ofertas exclusivas, descontos especiais e as melhores oportunidades de viagem diretamente no seu e-mail.
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <button className="group inline-flex items-center gap-2 bg-gradient-to-r from-blue-600 to-cyan-600 text-white px-8 py-4 rounded-full font-semibold hover:shadow-xl transition-all duration-300 hover:scale-105">
-                  <Phone className="w-5 h-5 group-hover:animate-bounce" />
-                  Fale Conosco
-                </button>
-                <button className="group inline-flex items-center gap-2 bg-white text-blue-600 border-2 border-blue-600 px-8 py-4 rounded-full font-semibold hover:bg-blue-50 hover:shadow-xl transition-all duration-300 hover:scale-105">
-                  <MessageCircle className="w-5 h-5 group-hover:animate-bounce" />
-                  WhatsApp
-                </button>
+            <div className="relative space-y-8">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="grid h-14 w-14 place-items-center rounded-2xl bg-gradient-to-br from-blue-500/20 to-cyan-500/30 text-blue-600 shadow">
+                    <MapPin className="h-7 w-7 animate-bounce" />
+                  </div>
+                  <div>
+                    <h2 className="text-3xl font-bold text-slate-900">Coleção de destinos</h2>
+                    <p className="text-sm text-slate-600">
+                      {destinationCount > 0
+                        ? "Clique para abrir o modal com fotos, valores e detalhes exclusivos de cada experiência."
+                        : "Cadastre um destino no dashboard para inaugurar esta vitrine inspiradora."}
+                    </p>
+                  </div>
+                </div>
+                <div className="inline-flex items-center gap-2 self-start rounded-full border border-blue-200/60 bg-blue-50/80 px-4 py-2 text-sm font-semibold text-blue-700 shadow-sm">
+                  <Sparkles className="h-4 w-4 text-blue-500" />
+                  <span>
+                    {destinationCount}{" "}
+                    {destinationCount === 1 ? "destino disponível" : "destinos disponíveis"}
+                  </span>
+                </div>
               </div>
+
+              {destinationsError ? (
+                <div className="flex items-start gap-4 rounded-2xl border border-amber-200 bg-amber-50/80 p-6 text-amber-800 shadow-md">
+                  <div className="grid h-12 w-12 place-items-center rounded-full bg-amber-100">
+                    <Clock className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold">Ops! Estamos atualizando a vitrine</h3>
+                    <p className="text-sm">
+                      Tente novamente em instantes ou fale com nossa equipe para receber recomendações personalizadas.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <DestinationGrid
+                  destinations={destinations}
+                  onDelete={session?.user ? deleteDestination : undefined}
+                />
+              )}
             </div>
           </div>
         </div>
       </section>
 
-      {/* Seção de Destinos */}
-      <section className="relative mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
-        {/* Header da seção de destinos */}
-        <div className="text-center mb-12">
-          <div className="inline-flex items-center gap-2 bg-gradient-to-r from-blue-100 to-cyan-100 px-6 py-2 rounded-full mb-4">
-            <Compass className="w-5 h-5 text-blue-600 animate-spin" style={{ animationDuration: '20s' }} />
-            <span className="text-sm font-semibold text-blue-700 uppercase tracking-wide">
-              Destinos Exclusivos
-            </span>
-          </div>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
-            Descubra Lugares Incríveis
-          </h2>
-          <p className="text-gray-600 max-w-3xl mx-auto">
-            Selecionamos cuidadosamente os melhores destinos para você viver experiências únicas. 
-            De praias paradisíacas a metrópoles vibrantes, temos a viagem perfeita para cada estilo.
-          </p>
-        </div>
+      {/* Seção complementar com serviços e diferenciais da agência */}
+      <section className="relative z-0">
+        <div className="mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
+          <div className="relative overflow-hidden rounded-3xl border border-white/20 bg-white/80 px-6 py-16 shadow-[0_35px_70px_-40px_rgba(14,116,144,0.45)] backdrop-blur lg:px-12">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white via-transparent to-blue-50" />
+            <div className="pointer-events-none absolute -top-16 left-10 h-40 w-40 rounded-full bg-blue-500/20 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-16 right-10 h-48 w-48 rounded-full bg-cyan-500/20 blur-3xl" />
 
-        {/* Categorias de Destinos */}
-        <div className="flex flex-wrap justify-center gap-3 mb-8">
-          {[
-            { icon: Waves, label: "Praias", bgColor: "hover:bg-blue-50", iconColor: "text-blue-500" },
-            { icon: Mountain, label: "Montanhas", bgColor: "hover:bg-green-50", iconColor: "text-green-500" },
-            { icon: Building, label: "Cidades", bgColor: "hover:bg-purple-50", iconColor: "text-purple-500" },
-            { icon: Palmtree, label: "Tropical", bgColor: "hover:bg-orange-50", iconColor: "text-orange-500" },
-            { icon: Camera, label: "Aventura", bgColor: "hover:bg-red-50", iconColor: "text-red-500" }
-          ].map((category, index) => (
-            <button
-              key={index}
-              className={`group inline-flex items-center gap-2 px-6 py-3 bg-white rounded-full shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-1 ${category.bgColor}`}
-            >
-              <category.icon className={`w-5 h-5 ${category.iconColor} group-hover:scale-110 transition-transform`} />
-              <span className="font-medium text-gray-700">{category.label}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Formulário de criação (apenas para usuários logados) */}
-        {session?.user && (
-          <div className="mb-12">
-            <div className="bg-gradient-to-r from-indigo-50 to-purple-50 rounded-2xl p-6 border border-indigo-200">
-              <div className="flex items-center gap-2 mb-4">
-                <Shield className="w-5 h-5 text-indigo-600" />
-                <h3 className="font-semibold text-indigo-900">Área Administrativa</h3>
-              </div>
-              <CreateDestinationForm action={createDestination} />
-            </div>
-          </div>
-        )}
-
-        {/* Lista de Destinos */}
-        <div className="space-y-6" id="destinos">
-          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mb-6">
-            <div className="flex items-center gap-3">
-              <MapPin className="w-6 h-6 text-blue-600 animate-bounce" />
-              <h3 className="text-2xl font-bold text-gray-800">Destinos Disponíveis</h3>
-            </div>
-            <div className="flex items-center gap-2 bg-gradient-to-r from-blue-100 to-cyan-100 px-4 py-2 rounded-full">
-              <Sparkles className="w-4 h-4 text-blue-600" />
-              <span className="text-sm font-semibold text-blue-700">
-                {destinations.length} {destinations.length === 1 ? 'destino incrível' : 'destinos incríveis'}
-              </span>
-            </div>
-          </div>
-
-          {destinationsError ? (
-            <div className="bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200 rounded-2xl p-6 flex items-start gap-3">
-              <div className="bg-amber-100 rounded-full p-2">
-                <Clock className="w-5 h-5 text-amber-600" />
-              </div>
-              <div>
-                <p className="font-semibold text-amber-800 mb-1">Ops! Pequeno contratempo</p>
-                <p className="text-sm text-amber-700">
-                  Estamos atualizando nossos destinos para você. Por favor, tente novamente em alguns instantes.
+            <div className="relative grid gap-10 lg:grid-cols-[1fr_1.1fr] lg:items-center">
+              <div className="text-center lg:text-left">
+                <div className="inline-flex items-center gap-3 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-blue-700 shadow">
+                  <div className="relative">
+                    <Plane className="h-6 w-6" />
+                    <Sparkles className="absolute -right-1 -top-1 h-4 w-4 text-yellow-500" />
+                  </div>
+                  Evastur, o seu parceiro de jornada
+                </div>
+                <h2 className="mt-6 text-3xl font-bold text-slate-900 md:text-4xl">
+                  Uma experiência premium do planejamento ao pouso
+                </h2>
+                <p className="mt-4 text-base text-slate-600">
+                  Nossa equipe acompanha cada etapa para garantir que você tenha memórias inesquecíveis. Conte com especialistas em destinos nacionais e internacionais, prontos para personalizar cada detalhe.
                 </p>
               </div>
-            </div>
-          ) : destinations.length === 0 ? (
-            <div className="bg-gradient-to-r from-gray-50 to-slate-50 rounded-3xl p-12 text-center">
-              <Globe className="w-16 h-16 text-gray-400 mx-auto mb-4 animate-spin" style={{ animationDuration: '20s' }} />
-              <h3 className="text-xl font-semibold text-gray-700 mb-2">
-                Novos destinos em breve!
-              </h3>
-              <p className="text-gray-600 max-w-md mx-auto">
-                Estamos preparando ofertas incríveis para você. Volte em breve ou entre em contato para saber mais.
-              </p>
-            </div>
-          ) : (
-            <DestinationGrid
-              destinations={destinations}
-              onDelete={session?.user ? deleteDestination : undefined}
-            />
-          )}
-        </div>
 
-        {/* Call to Action Final */}
-        <div className="mt-16 bg-gradient-to-r from-blue-600 to-cyan-600 rounded-3xl p-8 md:p-12 text-white text-center relative overflow-hidden">
-          <div className="absolute inset-0 bg-white opacity-10">
-            <div className="absolute inset-0" style={{
-              backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M0 40L40 0H20L0 20M40 40V20L20 40'/%3E%3C/g%3E%3C/svg%3E")`,
-            }}></div>
-          </div>
-          <div className="relative z-10">
-            <Heart className="w-12 h-12 mx-auto mb-4 animate-pulse" />
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">
-              Pronto para sua próxima aventura?
-            </h2>
-            <p className="text-xl mb-8 text-blue-100 max-w-2xl mx-auto">
-              Nossa equipe de especialistas está pronta para criar o roteiro perfeito para você!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <button className="group inline-flex items-center justify-center gap-2 bg-white text-blue-600 px-8 py-4 rounded-full font-bold hover:shadow-2xl transition-all duration-300 hover:scale-105">
-                <Mail className="w-5 h-5 group-hover:animate-bounce" />
-                Solicitar Orçamento
-                <ChevronRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-              </button>
-              <button className="group inline-flex items-center justify-center gap-2 bg-blue-700 text-white px-8 py-4 rounded-full font-bold hover:bg-blue-800 hover:shadow-2xl transition-all duration-300 hover:scale-105">
-                <Phone className="w-5 h-5 group-hover:animate-bounce" />
-                Ligar Agora
-              </button>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {[
+                  { icon: Luggage, title: "Pacotes completos", desc: "Hospedagem, passeios e transfers sob medida." },
+                  { icon: Ship, title: "Cruzeiros incríveis", desc: "Roteiros pelo Caribe, Mediterrâneo e Brasil." },
+                  { icon: Globe, title: "Viagens internacionais", desc: "Assessoria para visto, seguro e câmbio." },
+                  { icon: Shield, title: "Suporte 24/7", desc: "Atendimento dedicado durante toda a viagem." },
+                ].map((service) => (
+                  <div
+                    key={service.title}
+                    className="group relative overflow-hidden rounded-2xl border border-white/40 bg-white/90 p-6 shadow-lg transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl"
+                  >
+                    <div className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-br from-blue-500/10 to-cyan-500/20 transition-transform duration-500 group-hover:translate-y-0" />
+                    <div className="relative z-10 space-y-3">
+                      <service.icon className="h-8 w-8 text-blue-600 transition-transform duration-300 group-hover:scale-110" />
+                      <h3 className="text-lg font-semibold text-slate-900">{service.title}</h3>
+                      <p className="text-sm text-slate-600">{service.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="relative mt-12 grid gap-8 rounded-2xl border border-white/40 bg-white/80 p-6 shadow-lg backdrop-blur sm:grid-cols-3">
+              {[
+                { icon: TrendingUp, title: "Melhor preço garantido", desc: "Negociamos direto com fornecedores para ofertas imbatíveis." },
+                { icon: Heart, title: "Atendimento humanizado", desc: "Consultores dedicados que entendem seu estilo de viagem." },
+                { icon: Phone, title: "Suporte onde estiver", desc: "Fale com a Evastur por WhatsApp, telefone ou e-mail." },
+              ].map((benefit) => (
+                <div key={benefit.title} className="space-y-3 text-center sm:text-left">
+                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 text-blue-600 sm:mx-0">
+                    <benefit.icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-900">{benefit.title}</h3>
+                  <p className="text-sm text-slate-600">{benefit.desc}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="relative mt-12 overflow-hidden rounded-3xl border border-white/40 bg-gradient-to-br from-blue-600 to-cyan-600 p-8 text-white shadow-[0_45px_80px_-40px_rgba(37,99,235,0.6)]">
+              <div className="absolute inset-0 bg-white/10" />
+              <div className="relative z-10 text-center">
+                <Heart className="mx-auto h-12 w-12 animate-pulse" />
+                <h2 className="mt-4 text-3xl font-bold md:text-4xl">
+                  Pronto para sua próxima aventura?
+                </h2>
+                <p className="mt-3 text-base text-blue-100 md:text-lg">
+                  Nossa equipe está pronta para desenhar um roteiro único para você. Entre em contato e receba propostas personalizadas em minutos.
+                </p>
+                <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
+                  <button className="group inline-flex items-center justify-center gap-2 rounded-full bg-white px-8 py-4 text-base font-semibold text-blue-700 shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl">
+                    <Mail className="h-5 w-5 transition-transform group-hover:-translate-y-0.5" />
+                    Solicitar orçamento
+                    <ChevronRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                  </button>
+                  <button className="group inline-flex items-center justify-center gap-2 rounded-full border border-white/60 bg-transparent px-8 py-4 text-base font-semibold text-white transition-all duration-300 hover:scale-105 hover:bg-white/10">
+                    <MessageCircle className="h-5 w-5 transition-transform group-hover:-translate-y-0.5" />
+                    Falar no WhatsApp
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/components/destinations/destination-card.tsx
+++ b/components/destinations/destination-card.tsx
@@ -78,9 +78,13 @@ export function DestinationCard({ destination }: DestinationCardProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Card className="h-full cursor-pointer transition-transform duration-200 hover:-translate-y-1 hover:shadow-md">
+        <Card className="group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-3xl border border-white/30 bg-white/80 shadow-[0_25px_50px_-25px_rgba(14,116,144,0.35)] transition-all duration-500 hover:-translate-y-3 hover:shadow-[0_40px_80px_-30px_rgba(2,132,199,0.45)]">
+          <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-cyan-500/20" />
+          </div>
+
           <CardHeader className="gap-4">
-            <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-muted">
+            <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-white/60 bg-slate-100 shadow-inner">
               <Image
                 src={photos[activeIndex]}
                 alt={destination.name}
@@ -118,12 +122,12 @@ export function DestinationCard({ destination }: DestinationCardProps) {
                 </>
               )}
               {photos.length > 1 && (
-                <div className="absolute inset-x-0 bottom-2 flex justify-center gap-1">
+                <div className="absolute inset-x-0 bottom-3 flex justify-center gap-1">
                   {photos.map((photo, index) => (
                     <span
                       key={photo + index}
                       className={cn(
-                        "h-2 w-2 rounded-full bg-white/50",
+                        "h-2 w-2 rounded-full bg-white/40 backdrop-blur",
                         index === activeIndex && "bg-white"
                       )}
                     />
@@ -132,52 +136,51 @@ export function DestinationCard({ destination }: DestinationCardProps) {
               )}
             </div>
             <div className="space-y-1">
-              <CardTitle className="text-lg font-semibold text-slate-900">
+              <CardTitle className="text-lg font-bold text-slate-900">
                 {destination.name}
               </CardTitle>
-              <CardDescription className="flex items-center gap-2 text-sm text-slate-600">
+              <CardDescription className="flex items-center gap-2 text-sm font-medium text-slate-600">
                 <MapPin className="size-4 text-primary" />
-                {destination.city}
+                <span>{destination.city}</span>
               </CardDescription>
             </div>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="mt-auto space-y-4">
             <div className="flex items-center justify-between">
-              <span className="text-base font-semibold text-slate-900">
-                {formattedPrice}
-              </span>
-              <div className="flex items-center gap-1 text-sm text-amber-500">
+              <span className="text-lg font-bold text-slate-900">{formattedPrice}</span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-100/80 px-3 py-1 text-sm font-semibold text-amber-600 shadow-sm">
                 <Star className="size-4" />
-                <span>{destination.rating.toFixed(1)}</span>
-              </div>
+                {destination.rating.toFixed(1)}
+              </span>
             </div>
-            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
-              <span className="inline-flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-3 text-sm font-medium text-slate-600">
+              <span className="inline-flex items-center gap-2 rounded-full bg-slate-100/80 px-3 py-1">
                 <CalendarRange className="size-4 text-primary" />
                 {stayLabel}
               </span>
-              <span className="inline-flex items-center gap-2">
+              <span className="inline-flex items-center gap-2 rounded-full bg-slate-100/80 px-3 py-1">
                 <Users className="size-4 text-primary" />
                 {destination.peopleCount} pessoas
               </span>
             </div>
+            <div className="h-px w-full bg-gradient-to-r from-transparent via-blue-200/80 to-transparent" />
           </CardContent>
         </Card>
       </DialogTrigger>
-      <DialogContent className="max-w-3xl space-y-6">
+      <DialogContent className="max-w-3xl space-y-6 rounded-3xl border border-white/40 bg-white/95 p-8 shadow-[0_40px_80px_-35px_rgba(15,118,190,0.45)]">
         <DialogHeader className="space-y-2">
-          <DialogTitle className="text-2xl font-semibold text-slate-900">
+          <DialogTitle className="text-3xl font-bold text-slate-900">
             {destination.name}
           </DialogTitle>
-          <DialogDescription className="flex items-center gap-2 text-base text-slate-600">
-            <MapPin className="size-4 text-primary" />
-            {destination.city}
+          <DialogDescription className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700">
+            <MapPin className="size-4" />
+            <span>{destination.city}</span>
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-3 rounded-lg bg-slate-100 p-4 text-sm text-slate-700">
-            <p className="flex items-center gap-2 text-base font-medium text-slate-900">
+          <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-5 text-sm text-slate-700">
+            <p className="flex items-center gap-2 text-base font-semibold text-slate-900">
               <CalendarRange className="size-4 text-primary" />
               {stayLabel}
             </p>
@@ -193,9 +196,9 @@ export function DestinationCard({ destination }: DestinationCardProps) {
               <span className="font-medium text-slate-900">Investimento:</span> {formattedPrice}
             </p>
           </div>
-          <div className="space-y-2">
+          <div className="space-y-3">
             <h4 className="text-base font-semibold text-slate-900">Descrição</h4>
-            <p className="text-sm leading-relaxed text-slate-700">
+            <p className="rounded-2xl border border-slate-200 bg-white/80 p-4 text-sm leading-relaxed text-slate-700">
               {destination.description}
             </p>
           </div>
@@ -207,7 +210,7 @@ export function DestinationCard({ destination }: DestinationCardProps) {
             {photos.map((photo, index) => (
               <div
                 key={`${photo}-${index}`}
-                className="relative aspect-video overflow-hidden rounded-lg border"
+                className="group relative aspect-video overflow-hidden rounded-2xl border border-white/60 bg-slate-100 shadow-inner"
               >
                 <Image
                   src={photo}
@@ -224,7 +227,10 @@ export function DestinationCard({ destination }: DestinationCardProps) {
         <div className="flex justify-end">
           <button
             type="button"
-            className={cn(buttonVariants({ variant: "outline" }), "min-w-[140px]")}
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "min-w-[160px] rounded-full border-primary/40 bg-primary/5 text-primary hover:bg-primary/10"
+            )}
             onClick={() => {
               const url = `https://www.google.com/maps/search/${encodeURIComponent(
                 destination.city

--- a/components/destinations/destination-grid.tsx
+++ b/components/destinations/destination-grid.tsx
@@ -1,3 +1,5 @@
+import { Compass } from "lucide-react";
+
 import type {
   DestinationDeleteAction,
   SerializedDestination,
@@ -14,14 +16,24 @@ interface DestinationGridProps {
 export function DestinationGrid({ destinations, onDelete }: DestinationGridProps) {
   if (destinations.length === 0) {
     return (
-      <p className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-600">
-        Ainda não há destinos cadastrados. Assim que você adicionar um destino, ele aparecerá aqui.
-      </p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-200 bg-white/80 p-12 text-center shadow-lg">
+        <div className="grid h-16 w-16 place-items-center rounded-full bg-blue-50 text-blue-600 shadow-inner">
+          <Compass className="h-8 w-8" />
+        </div>
+        <div className="space-y-2">
+          <p className="text-lg font-semibold text-slate-900">
+            Nenhum destino cadastrado ainda
+          </p>
+          <p className="text-sm text-slate-600">
+            Cadastre novas experiências pelo dashboard para montar uma vitrine encantadora por aqui.
+          </p>
+        </div>
+      </div>
     );
   }
 
   return (
-    <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
       {destinations.map((destination) =>
         onDelete ? (
           <ManageableDestinationCard

--- a/components/destinations/manageable-destination-card.tsx
+++ b/components/destinations/manageable-destination-card.tsx
@@ -27,11 +27,11 @@ export function ManageableDestinationCard({
   );
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <DestinationCard destination={destination} />
       <form
         action={formAction}
-        className="flex flex-col gap-2 rounded-lg border border-dashed border-slate-200 bg-white/70 p-3 sm:flex-row sm:items-center sm:justify-between"
+        className="flex flex-col gap-3 rounded-2xl border border-red-100/60 bg-white/80 p-4 shadow-md transition-colors hover:border-red-200 sm:flex-row sm:items-center sm:justify-between"
       >
         <input type="hidden" name="destinationId" value={destination.id} />
         <Button
@@ -39,14 +39,14 @@ export function ManageableDestinationCard({
           variant="destructive"
           size="sm"
           disabled={isPending}
-          className="min-w-[140px]"
+          className="min-w-[160px] rounded-full"
         >
           {isPending ? "Excluindo..." : "Excluir destino"}
         </Button>
         {state.status !== "idle" && state.message ? (
           <p
             className={cn(
-              "text-sm",
+              "text-sm font-medium",
               state.status === "error" ? "text-red-600" : "text-emerald-600"
             )}
             role="status"


### PR DESCRIPTION
## Summary
- relocate the destination creation server action to the dashboard and expose a dedicated admin card for it
- redesign the Destinos page to highlight the destination list first with richer styling and improved fallback states
- refresh destination cards, grid and management controls with gradient treatments and modern interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e292d5c6cc8333b9d2be93e3e9ccce