### PR TITLE
Broaden travel budget form layout on desktop

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -154,7 +154,7 @@ export default function Hero({ images, userName }: HeroProps) {
 
       {/* Conteúdo principal */}
       <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 md:py-24 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start xl:grid-cols-[minmax(0,1fr)_460px]">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_520px] lg:items-start xl:grid-cols-[minmax(0,1fr)_600px] 2xl:grid-cols-[minmax(0,1fr)_640px]">
           <div className="flex flex-col gap-6 sm:gap-8 lg:pr-8 xl:pr-12">
             {/* Badge */}
             <div className="group inline-flex w-fit animate-[fadeIn_1s_ease-out] items-center gap-2.5 rounded-full border border-white/25 bg-white/15 px-4 py-2 text-xs font-medium text-white shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:border-white/40 hover:bg-white/20 sm:text-sm">

--- a/components/home/quote-form.tsx
+++ b/components/home/quote-form.tsx
@@ -151,7 +151,7 @@ export function QuoteForm() {
       {...formMotion}
       transition={{ duration: 0.6, ease: "easeOut" }}
       onSubmit={handleSubmit}
-      className="relative overflow-hidden rounded-3xl border border-white/20 bg-white/15 p-6 shadow-[0_35px_120px_-45px_rgba(15,23,42,0.9)] backdrop-blur-xl sm:p-7 md:p-8"
+      className="relative w-full overflow-hidden rounded-3xl border border-white/20 bg-white/15 p-6 shadow-[0_35px_120px_-45px_rgba(15,23,42,0.9)] backdrop-blur-xl sm:p-7 md:p-8"
     >
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-blue-500/10 to-purple-500/10" />
       <div className="pointer-events-none absolute -left-10 top-24 size-36 rounded-full bg-blue-400/20 blur-3xl" />


### PR DESCRIPTION
## Summary
- increase the hero section grid column widths on large viewports so the travel budget form has more space on desktop
- ensure the quote form stretches to the full width of its column for better readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a7d4a3d88333aa2de3f8d3cd23c7