### PR TITLE
Add role-aware authentication and modernized auth UI

### DIFF
--- a/app/api/dev/create-user/route.ts
+++ b/app/api/dev/create-user/route.ts
@@ -6,7 +6,7 @@ import bcrypt from "bcryptjs";
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
-  const { username, password, imageUrl } = await request.json();
+  const { username, password, imageUrl, fullName, email, role } = await request.json();
 
   if (!username || !password) {
     return NextResponse.json(
@@ -24,17 +24,32 @@ export async function POST(request: Request) {
   }
 
   const hash = await bcrypt.hash(password, 10);
+  const normalizedFullName =
+    typeof fullName === "string" && fullName.trim().length > 0
+      ? fullName.trim()
+      : normalizedUsername;
+  const normalizedEmail =
+    typeof email === "string" && email.trim().length > 0
+      ? String(email).trim().toLowerCase()
+      : `${normalizedUsername}@example.com`;
+  const normalizedRole = role === "admin" ? "admin" : "user";
 
   const user = await prisma.user.upsert({
     where: { username: normalizedUsername },
     update: {
       passwordHash: hash,
       imageUrl: imageUrl ? String(imageUrl) : undefined,
+      fullName: normalizedFullName,
+      email: normalizedEmail,
+      role: normalizedRole,
     },
     create: {
       username: normalizedUsername,
       passwordHash: hash,
       imageUrl: imageUrl ? String(imageUrl) : null,
+      fullName: normalizedFullName,
+      email: normalizedEmail,
+      role: normalizedRole,
     },
   });
 

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -7,17 +7,67 @@ import { hashPassword } from "@/lib/hash";
 
 export const runtime = "nodejs";
 
-const signupSchema = z.object({
-  username: z
-    .string()
-    .min(3, "Usuário deve ter pelo menos 3 caracteres")
-    .max(32, "Usuário deve ter no máximo 32 caracteres")
-    .regex(/^[a-zA-Z0-9._-]+$/, "Use apenas letras, números, ponto, traço e sublinhado"),
-  password: z
-    .string()
-    .min(6, "Senha deve ter pelo menos 6 caracteres")
-    .max(128, "Senha deve ter no máximo 128 caracteres"),
-});
+const ADMIN_CODE = "258790" as const;
+
+const signupSchema = z
+  .object({
+    username: z
+      .string()
+      .min(3, "Usuário deve ter pelo menos 3 caracteres")
+      .max(32, "Usuário deve ter no máximo 32 caracteres")
+      .regex(/^[a-zA-Z0-9._-]+$/, "Use apenas letras, números, ponto, traço e sublinhado")
+      .trim(),
+    fullName: z
+      .string()
+      .min(3, "Nome completo deve ter pelo menos 3 caracteres")
+      .max(80, "Nome completo deve ter no máximo 80 caracteres")
+      .transform((value) => value.trim().replace(/\s+/g, " ")),
+    email: z
+      .string()
+      .min(1, "E-mail é obrigatório")
+      .email("E-mail inválido")
+      .max(160, "E-mail deve ter no máximo 160 caracteres")
+      .trim()
+      .toLowerCase(),
+    password: z
+      .string()
+      .min(6, "Senha deve ter pelo menos 6 caracteres")
+      .max(128, "Senha deve ter no máximo 128 caracteres"),
+    confirmPassword: z
+      .string()
+      .min(6, "Confirme sua senha")
+      .max(128, "Confirmação deve ter no máximo 128 caracteres"),
+    profileType: z.enum(["user", "admin"], {
+      errorMap: () => ({ message: "Tipo de perfil inválido" }),
+    }),
+    adminCode: z.string().trim().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        path: ["confirmPassword"],
+        code: z.ZodIssueCode.custom,
+        message: "As senhas não coincidem",
+      });
+    }
+
+    if (data.profileType === "admin") {
+      const code = data.adminCode?.trim();
+      if (!code) {
+        ctx.addIssue({
+          path: ["adminCode"],
+          code: z.ZodIssueCode.custom,
+          message: "Informe o código de administrador",
+        });
+      } else if (code !== ADMIN_CODE) {
+        ctx.addIssue({
+          path: ["adminCode"],
+          code: z.ZodIssueCode.custom,
+          message: "Código de administrador inválido",
+        });
+      }
+    }
+  });
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
@@ -28,19 +78,33 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
-  const { username, password } = parsed.data;
+  const { username, password, fullName, email, profileType } = parsed.data;
+  const role = profileType === "admin" ? "admin" : "user";
 
   try {
     const passwordHash = await hashPassword(password);
     const user = await prisma.user.create({
-      data: { username, passwordHash },
-      select: { id: true, username: true },
+      data: { username, passwordHash, fullName, email, role },
+      select: { id: true, username: true, role: true },
     });
 
-    return NextResponse.json({ id: user.id, username: user.username }, { status: 201 });
+    return NextResponse.json(
+      { id: user.id, username: user.username, role: user.role },
+      { status: 201 },
+    );
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      return NextResponse.json({ error: "Usuário já cadastrado" }, { status: 409 });
+      const target = error.meta?.target;
+      const fields = Array.isArray(target)
+        ? target
+        : typeof target === "string"
+          ? [target]
+          : [];
+      const message = fields.includes("email")
+        ? "E-mail já cadastrado"
+        : "Usuário já cadastrado";
+
+      return NextResponse.json({ error: message }, { status: 409 });
     }
 
     console.error("Falha ao cadastrar usuário", error);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -27,6 +27,10 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
+  if (session.user.role !== "admin") {
+    redirect("/usuario");
+  }
+
   let backgroundUrl: string | null = null;
 
   try {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,30 @@ import { FormEvent, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { Plane, Sparkles, Eye, EyeOff, ArrowRight, AlertCircle } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  Plane,
+  Sparkles,
+  Eye,
+  EyeOff,
+  ArrowRight,
+  AlertCircle,
+  CheckCircle2,
+  UserRound,
+  LockKeyhole,
+} from "lucide-react";
+
+const fieldMotion = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -12 },
+};
+const fieldTransition = { duration: 0.3, ease: "easeOut" as const };
+const ERROR_MESSAGES: Record<string, string> = {
+  user_not_found: "Usuário não encontrado.",
+  invalid_password: "Senha incorreta.",
+  CredentialsSignin: "Credenciais inválidas. Verifique usuário e senha.",
+};
 
 export default function LoginPage() {
   // Navegação / callback (mesmo backend)
@@ -17,34 +40,81 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [showPass, setShowPass] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Submit (mesmo signIn + redirects)
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
+    setSuccess(null);
     setLoading(true);
 
-    const result = await signIn("credentials", {
-      redirect: false,
-      username,
-      password,
-      callbackUrl,
-    });
+    const normalizedUsername = username.trim();
+    if (!normalizedUsername) {
+      setError("Informe seu usuário.");
+      setLoading(false);
+      return;
+    }
 
-    setLoading(false);
+    if (!password) {
+      setError("Informe sua senha.");
+      setLoading(false);
+      return;
+    }
 
-    if (!result) {
+    try {
+      const result = await signIn("credentials", {
+        redirect: false,
+        username: normalizedUsername,
+        password,
+        callbackUrl,
+      });
+
+      if (!result) {
+        setError("Erro inesperado ao fazer login.");
+        return;
+      }
+
+      if (!result.ok) {
+        const message =
+          (result.code && ERROR_MESSAGES[result.code]) ??
+          (result.error && ERROR_MESSAGES[result.error]) ??
+          "Não foi possível entrar. Confira suas credenciais.";
+        setError(message);
+        return;
+      }
+
+      setSuccess("Login realizado com sucesso! Redirecionando...");
+
+      try {
+        const response = await fetch("/api/auth/session");
+        if (response.ok) {
+          const session = await response.json();
+          const role = session?.user?.role === "admin" ? "admin" : "user";
+          const destination =
+            callbackUrl && callbackUrl !== "/"
+              ? callbackUrl
+              : role === "admin"
+                ? "/dashboard"
+                : "/usuario";
+
+          router.push(destination);
+          router.refresh();
+          return;
+        }
+      } catch (sessionError) {
+        console.error("Falha ao recuperar sessão após login", sessionError);
+      }
+
+      router.push(callbackUrl);
+      router.refresh();
+    } catch (authError) {
+      console.error("Falha ao fazer login", authError);
       setError("Erro inesperado ao fazer login.");
-      return;
+    } finally {
+      setLoading(false);
     }
-    if (result.error) {
-      setError("Credenciais inválidas.");
-      return;
-    }
-
-    router.push(result.url ?? callbackUrl);
-    router.refresh();
   };
 
   return (
@@ -86,38 +156,78 @@ export default function LoginPage() {
             <p className="mt-1 text-sm text-slate-600">Use seu usuário e senha para continuar.</p>
           </div>
 
-          {/* Erro (quando houver) */}
-          {error && (
-            <div className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              <AlertCircle className="h-4 w-4" />
-              <span>{error}</span>
-            </div>
-          )}
+          {/* feedbacks */}
+          <AnimatePresence mode="wait">
+            {error && (
+              <motion.div
+                key="login-error"
+                initial={fieldMotion.initial}
+                animate={fieldMotion.animate}
+                exit={fieldMotion.exit}
+                transition={fieldTransition}
+                className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              >
+                <AlertCircle className="h-4 w-4" />
+                <span>{error}</span>
+              </motion.div>
+            )}
+          </AnimatePresence>
+          <AnimatePresence mode="wait">
+            {success && (
+              <motion.div
+                key="login-success"
+                initial={fieldMotion.initial}
+                animate={fieldMotion.animate}
+                exit={fieldMotion.exit}
+                transition={fieldTransition}
+                className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                <span>{success}</span>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* Formulário (fluxo idêntico ao seu) */}
           <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Usuário */}
-            <div className="space-y-1.5">
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
               <label htmlFor="username" className="text-sm font-medium text-slate-800">
                 Usuário
               </label>
-              <input
-                id="username"
-                name="username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                autoComplete="username"
-                required
-                className="w-full rounded-xl border border-slate-200 bg-white/90 px-3.5 py-2.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-              />
-            </div>
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <UserRound className="h-4 w-4" />
+                </span>
+                <input
+                  id="username"
+                  name="username"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  autoComplete="username"
+                  required
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                />
+              </div>
+            </motion.div>
 
-            {/* Senha */}
-            <div className="space-y-1.5">
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
               <label htmlFor="password" className="text-sm font-medium text-slate-800">
                 Senha
               </label>
               <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <LockKeyhole className="h-4 w-4" />
+                </span>
                 <input
                   id="password"
                   name="password"
@@ -126,7 +236,7 @@ export default function LoginPage() {
                   onChange={(e) => setPassword(e.target.value)}
                   autoComplete="current-password"
                   required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 px-3.5 py-2.5 pr-10 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
                 />
                 <button
                   type="button"
@@ -137,13 +247,17 @@ export default function LoginPage() {
                   {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
-            </div>
+            </motion.div>
 
-            {/* Ações */}
-            <button
+            <motion.button
               type="submit"
               disabled={loading}
-              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-blue-500/30 disabled:opacity-60"
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={{ ...fieldTransition, delay: 0.05 }}
+              whileHover={{ translateY: loading ? 0 : -2 }}
+              whileTap={{ scale: loading ? 1 : 0.98 }}
+              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {loading ? (
                 <>
@@ -156,7 +270,7 @@ export default function LoginPage() {
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </>
               )}
-            </button>
+            </motion.button>
           </form>
 
           {/* Links auxiliares */}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   Sparkles,
   Plane,
@@ -13,20 +14,55 @@ import {
   ArrowRight,
   ShieldCheck,
   UserPlus,
+  Mail,
+  LockKeyhole,
+  UserCog,
+  UserRound,
 } from "lucide-react";
+
+const ADMIN_CODE = "258790" as const;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const fieldMotion = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -12 },
+};
+const fieldTransition = { duration: 0.32, ease: "easeOut" as const };
 
 export default function SignupPage() {
   const router = useRouter();
 
-  // estado do formulário (backend inalterado)
+  // estado do formulário
   const [username, setUsername] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [profileType, setProfileType] = useState<"user" | "admin">("user");
+  const [adminCode, setAdminCode] = useState("");
 
   // UI states
   const [showPass, setShowPass] = useState(false);
+  const [showConfirmPass, setShowConfirmPass] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const profileOptions = [
+    {
+      value: "user" as const,
+      label: "Perfil comum",
+      description: "Visualiza destinos e gerencia apenas o próprio perfil.",
+      icon: UserRound,
+    },
+    {
+      value: "admin" as const,
+      label: "Administrador",
+      description: "Acessa o dashboard completo e edita todos os conteúdos.",
+      icon: UserCog,
+    },
+  ];
 
   // força simples da senha (apenas UI)
   const strength = useMemo(() => {
@@ -54,13 +90,34 @@ export default function SignupPage() {
     setError(null);
     setSuccess(null);
 
+    const normalizedUsername = username.trim();
+    const normalizedFullName = fullName.trim();
+    const normalizedEmail = email.trim();
+    const normalizedAdminCode = adminCode.trim();
+
     // pequenas validações de UX (front-only)
-    if (username.trim().length < 3) {
+    if (normalizedFullName.length < 3) {
+      setError("Informe seu nome completo com pelo menos 3 caracteres.");
+      return;
+    }
+    if (!EMAIL_REGEX.test(normalizedEmail)) {
+      setError("Informe um e-mail válido.");
+      return;
+    }
+    if (normalizedUsername.length < 3) {
       setError("O usuário deve ter pelo menos 3 caracteres.");
       return;
     }
     if (password.length < 6) {
       setError("A senha deve ter pelo menos 6 caracteres.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("As senhas precisam ser iguais.");
+      return;
+    }
+    if (profileType === "admin" && normalizedAdminCode !== ADMIN_CODE) {
+      setError("Código de administrador incorreto.");
       return;
     }
 
@@ -69,7 +126,15 @@ export default function SignupPage() {
       const response = await fetch("/api/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({
+          username: normalizedUsername,
+          fullName: normalizedFullName,
+          email: normalizedEmail,
+          password,
+          confirmPassword,
+          profileType,
+          adminCode: profileType === "admin" ? normalizedAdminCode : undefined,
+        }),
       });
 
       const data = await response.json();
@@ -78,10 +143,19 @@ export default function SignupPage() {
         return;
         }
 
-      setSuccess("Cadastro realizado com sucesso! Redirecionando para o login…");
+      setSuccess(
+        profileType === "admin"
+          ? "Administrador cadastrado com sucesso! Redirecionando para o login…"
+          : "Cadastro realizado com sucesso! Redirecionando para o login…",
+      );
       setUsername("");
+      setFullName("");
+      setEmail("");
       setPassword("");
-      setTimeout(() => router.push("/login"), 1000);
+      setConfirmPassword("");
+      setProfileType("user");
+      setAdminCode("");
+      setTimeout(() => router.push("/login"), 1200);
     } catch (err) {
       console.error(err);
       setError("Erro inesperado ao cadastrar.");
@@ -129,65 +203,154 @@ export default function SignupPage() {
           </div>
 
           {/* alertas */}
-          {error && (
-            <div className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              <AlertCircle className="h-4 w-4" />
-              <span>{error}</span>
-            </div>
-          )}
-          {success && (
-            <div className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
-              <CheckCircle2 className="h-4 w-4" />
-              <span>{success}</span>
-            </div>
-          )}
+          <AnimatePresence mode="wait">
+            {error && (
+              <motion.div
+                key="error"
+                initial={fieldMotion.initial}
+                animate={fieldMotion.animate}
+                exit={fieldMotion.exit}
+                transition={fieldTransition}
+                className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              >
+                <AlertCircle className="h-4 w-4" />
+                <span>{error}</span>
+              </motion.div>
+            )}
+          </AnimatePresence>
+          <AnimatePresence mode="wait">
+            {success && (
+              <motion.div
+                key="success"
+                initial={fieldMotion.initial}
+                animate={fieldMotion.animate}
+                exit={fieldMotion.exit}
+                transition={fieldTransition}
+                className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                <span>{success}</span>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* form */}
           <form onSubmit={handleSubmit} className="space-y-4">
-            {/* usuário */}
-            <div className="space-y-1.5">
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
+              <label htmlFor="fullName" className="text-sm font-medium text-slate-800">
+                Nome completo
+              </label>
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <UserPlus className="h-4 w-4" />
+                </span>
+                <input
+                  id="fullName"
+                  name="fullName"
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  placeholder="João Silva"
+                  autoComplete="name"
+                  required
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                />
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
+              <label htmlFor="email" className="text-sm font-medium text-slate-800">
+                E-mail
+              </label>
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <Mail className="h-4 w-4" />
+                </span>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="voce@empresa.com"
+                  autoComplete="email"
+                  required
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                />
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
               <label htmlFor="username" className="text-sm font-medium text-slate-800">
                 Usuário
               </label>
-              <input
-                id="username"
-                name="username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                autoComplete="username"
-                required
-                className="w-full rounded-xl border border-slate-200 bg-white/90 px-3.5 py-2.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-              />
-            </div>
-
-            {/* senha */}
-            <div className="space-y-1.5">
-              <label htmlFor="password" className="text-sm font-medium text-slate-800">
-                Senha
-              </label>
               <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <UserRound className="h-4 w-4" />
+                </span>
                 <input
-                  id="password"
-                  name="password"
-                  type={showPass ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete="new-password"
+                  id="username"
+                  name="username"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="usuario.evastur"
+                  autoComplete="username"
                   required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 px-3.5 py-2.5 pr-10 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
                 />
-                <button
-                  type="button"
-                  aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
-                  onClick={() => setShowPass((v) => !v)}
-                  className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
-                >
-                  {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
               </div>
+            </motion.div>
 
-              {/* força da senha (apenas visual) */}
-              <div className="mt-2 space-y-1">
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-2"
+            >
+              <div className="space-y-1.5">
+                <label htmlFor="password" className="text-sm font-medium text-slate-800">
+                  Senha
+                </label>
+                <div className="relative">
+                  <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                    <LockKeyhole className="h-4 w-4" />
+                  </span>
+                  <input
+                    id="password"
+                    name="password"
+                    type={showPass ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Crie uma senha segura"
+                    autoComplete="new-password"
+                    required
+                    className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                  />
+                  <button
+                    type="button"
+                    aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
+                    onClick={() => setShowPass((v) => !v)}
+                    className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
+                  >
+                    {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-1">
                 <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
                   <div
                     className={`h-full ${strengthBarClass} transition-all`}
@@ -196,16 +359,133 @@ export default function SignupPage() {
                 </div>
                 <div className="flex items-center gap-2 text-xs text-slate-600">
                   <ShieldCheck className="h-3.5 w-3.5 text-blue-600" />
-                  <span>Força da senha: <strong>{strengthLabel}</strong></span>
+                  <span>
+                    Força da senha: <strong>{strengthLabel}</strong>
+                  </span>
                 </div>
               </div>
-            </div>
+            </motion.div>
 
-            {/* botão */}
-            <button
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-1.5"
+            >
+              <label htmlFor="confirmPassword" className="text-sm font-medium text-slate-800">
+                Confirmar senha
+              </label>
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                  <LockKeyhole className="h-4 w-4" />
+                </span>
+                <input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type={showConfirmPass ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Repita a senha"
+                  autoComplete="new-password"
+                  required
+                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                />
+                <button
+                  type="button"
+                  aria-label={showConfirmPass ? "Ocultar confirmação" : "Mostrar confirmação"}
+                  onClick={() => setShowConfirmPass((v) => !v)}
+                  className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
+                >
+                  {showConfirmPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={fieldTransition}
+              className="space-y-2"
+            >
+              <p className="text-sm font-medium text-slate-800">Tipo de perfil</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {profileOptions.map((option) => {
+                  const OptionIcon = option.icon;
+                  const isActive = profileType === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setProfileType(option.value)}
+                      aria-pressed={isActive}
+                      className={`group flex w-full flex-col items-start gap-2 rounded-2xl border px-4 py-3 text-left transition-all ${
+                        isActive
+                          ? "border-blue-400 bg-blue-50/80 text-blue-900 shadow-lg shadow-blue-500/20"
+                          : "border-slate-200 bg-white/70 text-slate-700 hover:border-blue-200 hover:bg-blue-50/40"
+                      }`}
+                    >
+                      <div
+                        className={`grid h-10 w-10 place-items-center rounded-xl transition-colors ${
+                          isActive ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-500"
+                        }`}
+                      >
+                        <OptionIcon className="h-5 w-5" />
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-sm font-semibold">{option.label}</p>
+                        <p className="text-xs text-slate-500">{option.description}</p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </motion.div>
+
+            <AnimatePresence initial={false}>
+              {profileType === "admin" && (
+                <motion.div
+                  key="admin-code"
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  exit={fieldMotion.exit}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
+                >
+                  <label htmlFor="adminCode" className="text-sm font-medium text-slate-800">
+                    Código de administrador
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <ShieldCheck className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="adminCode"
+                      name="adminCode"
+                      type="password"
+                      value={adminCode}
+                      onChange={(e) => setAdminCode(e.target.value)}
+                      placeholder="Informe o código 258790"
+                      autoComplete="one-time-code"
+                      required
+                      className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                    />
+                  </div>
+                  <p className="text-xs text-slate-500">
+                    Apenas gestores autorizados podem criar contas administrativas.
+                  </p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            <motion.button
               type="submit"
               disabled={loading}
-              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-blue-500/30 disabled:opacity-60"
+              initial={fieldMotion.initial}
+              animate={fieldMotion.animate}
+              transition={{ ...fieldTransition, delay: 0.05 }}
+              whileHover={{ translateY: loading ? 0 : -2 }}
+              whileTap={{ scale: loading ? 1 : 0.98 }}
+              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {loading ? (
                 <>
@@ -218,7 +498,7 @@ export default function SignupPage() {
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </>
               )}
-            </button>
+            </motion.button>
           </form>
 
           {/* rodapé do card */}

--- a/app/usuario/page.tsx
+++ b/app/usuario/page.tsx
@@ -15,7 +15,11 @@ export default async function UsuarioPage() {
   }
 
   const { user } = session;
-  const displayName = user.name?.trim() ? user.name : "Usuário";
+  const displayName = user.fullName?.trim()
+    ? user.fullName
+    : user.name?.trim()
+      ? user.name
+      : "Usuário";
 
   return (
     // Layout principal com o cartão de informações e o formulário de upload de foto.
@@ -43,6 +47,15 @@ export default async function UsuarioPage() {
           <div className="space-y-1 text-sm text-slate-700">
             <p>
               <strong>Nome:</strong> {displayName}
+            </p>
+            <p>
+              <strong>Usuário:</strong> {user.username}
+            </p>
+            <p>
+              <strong>E-mail:</strong> {user.email ?? "Não informado"}
+            </p>
+            <p>
+              <strong>Perfil:</strong> {user.role === "admin" ? "Administrador" : "Comum"}
             </p>
             <p>
               <strong>ID do usuário:</strong> {user.id}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
+import { CredentialsSignin } from "next-auth";
 // import Google from "next-auth/providers/google";
 import { z } from "zod";
 
@@ -41,18 +42,26 @@ export const {
         }
 
         if (!user) {
-          return null;
+          const error = new CredentialsSignin("Usuário não encontrado");
+          error.code = "user_not_found";
+          throw error;
         }
 
         const ok = await verifyPassword(password, user.passwordHash);
         if (!ok) {
-          return null;
+          const error = new CredentialsSignin("Senha incorreta");
+          error.code = "invalid_password";
+          throw error;
         }
 
         return {
           id: user.id.toString(),
-          name: user.username,
+          name: user.fullName ?? user.username,
           image: user.imageUrl ?? undefined,
+          email: user.email,
+          role: user.role,
+          username: user.username,
+          fullName: user.fullName,
         };
       },
     }),
@@ -67,18 +76,32 @@ export const {
         token.userId = user.id;
         token.name = user.name ?? null;
         token.picture = user.image ?? null;
+        token.role = (user as { role?: "user" | "admin" }).role ?? "user";
+        token.username = (user as { username?: string }).username ?? token.username;
+        token.fullName = (user as { fullName?: string | null }).fullName ?? token.fullName ?? null;
+        token.email = (user as { email?: string | null }).email ?? token.email ?? null;
       }
 
       if (token.userId) {
         try {
           const dbUser = await prisma.user.findUnique({
             where: { id: Number(token.userId) },
-            select: { username: true, imageUrl: true },
+            select: {
+              username: true,
+              imageUrl: true,
+              role: true,
+              fullName: true,
+              email: true,
+            },
           });
 
           if (dbUser) {
-            token.name = dbUser.username;
+            token.name = dbUser.fullName ?? dbUser.username;
             token.picture = dbUser.imageUrl ?? null;
+            token.role = (dbUser.role as "user" | "admin") ?? "user";
+            token.username = dbUser.username;
+            token.fullName = dbUser.fullName ?? null;
+            token.email = dbUser.email ?? null;
           }
         } catch {
           // ignore database lookup errors in JWT callback
@@ -90,8 +113,12 @@ export const {
     async session({ session, token }) {
       if (session.user) {
         session.user.id = token.userId ?? "";
-        session.user.name = token.name ?? session.user.name ?? null;
+        session.user.name = token.fullName ?? token.name ?? session.user.name ?? null;
         session.user.image = token.picture ?? null;
+        session.user.role = (token.role as "user" | "admin") ?? "user";
+        session.user.username = token.username ?? session.user.username ?? "";
+        session.user.fullName = token.fullName ?? session.user.fullName ?? null;
+        session.user.email = token.email ?? session.user.email ?? null;
       }
 
       return session;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,9 @@ datasource db {
 model User {
   id           Int      @id @default(autoincrement())
   username     String   @unique
+  fullName     String
+  email        String   @unique
+  role         String   @default("user")
   passwordHash String
   imageUrl     String?
   createdAt    DateTime @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,11 +11,20 @@ async function main() {
 
   const user = await prisma.user.upsert({
     where: { username },
-    update: { passwordHash, imageUrl: avatarUrl },
+    update: {
+      passwordHash,
+      imageUrl: avatarUrl,
+      fullName: "Usuário Demo",
+      email: "demo@evastur.com",
+      role: "admin",
+    },
     create: {
       username,
       passwordHash,
       imageUrl: avatarUrl,
+      fullName: "Usuário Demo",
+      email: "demo@evastur.com",
+      role: "admin",
     },
     select: { id: true, username: true },
   });

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -8,6 +8,9 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       image?: string | null;
+      role: "user" | "admin";
+      username: string;
+      fullName?: string | null;
     };
   }
 }
@@ -16,5 +19,9 @@ declare module "next-auth/jwt" {
   interface JWT {
     userId?: string;
     picture?: string | null;
+    role?: "user" | "admin";
+    username?: string;
+    fullName?: string | null;
+    email?: string | null;
   }
 }


### PR DESCRIPTION
## Summary
- extend the Prisma user model and seed/dev utilities with full name, email and role metadata
- enforce admin code validation and role assignment during signup while propagating role information through NextAuth sessions
- redesign the signup and login screens with animated, role-aware forms and role-based redirects for admins and users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2aeae052883338ed9383f0ae759c5