### PR TITLE
Restrict admin link to admins and improve login feedback

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -26,8 +26,16 @@ const fieldTransition = { duration: 0.3, ease: "easeOut" as const };
 const ERROR_MESSAGES: Record<string, string> = {
   user_not_found: "Usuário não encontrado.",
   invalid_password: "Senha incorreta.",
+  database_error:
+    "Não foi possível validar suas credenciais agora. Tente novamente em instantes.",
+  verification_error:
+    "Não foi possível validar suas credenciais agora. Tente novamente em instantes.",
   CredentialsSignin: "Credenciais inválidas. Verifique usuário e senha.",
+  CallbackRouteError: "Não foi possível concluir o login. Tente novamente.",
 };
+
+const DEFAULT_ERROR_MESSAGE =
+  "Não foi possível entrar. Confira suas credenciais e tente novamente.";
 
 export default function LoginPage() {
   // Navegação / callback (mesmo backend)
@@ -72,7 +80,7 @@ export default function LoginPage() {
       });
 
       if (!result) {
-        setError("Erro inesperado ao fazer login.");
+        setError(DEFAULT_ERROR_MESSAGE);
         return;
       }
 
@@ -80,7 +88,14 @@ export default function LoginPage() {
         const message =
           (result.code && ERROR_MESSAGES[result.code]) ??
           (result.error && ERROR_MESSAGES[result.error]) ??
-          "Não foi possível entrar. Confira suas credenciais.";
+          (result.status >= 500
+            ? "Erro inesperado no servidor. Tente novamente em instantes."
+            : DEFAULT_ERROR_MESSAGE);
+
+        if (result.code === "invalid_password") {
+          setPassword("");
+        }
+
         setError(message);
         return;
       }
@@ -165,6 +180,8 @@ export default function LoginPage() {
                 animate={fieldMotion.animate}
                 exit={fieldMotion.exit}
                 transition={fieldTransition}
+                role="alert"
+                aria-live="assertive"
                 className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
               >
                 <AlertCircle className="h-4 w-4" />
@@ -180,6 +197,8 @@ export default function LoginPage() {
                 animate={fieldMotion.animate}
                 exit={fieldMotion.exit}
                 transition={fieldTransition}
+                role="status"
+                aria-live="polite"
                 className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
               >
                 <CheckCircle2 className="h-4 w-4" />

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -31,6 +31,7 @@ interface NavbarProps {
 export function Navbar({ user }: NavbarProps) {
   const pathname = usePathname();
   const isAuthenticated = Boolean(user);
+  const isAdmin = user?.role === "admin";
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
@@ -162,21 +163,25 @@ export function Navbar({ user }: NavbarProps) {
             {/* DESKTOP USER ACTIONS - Melhorado */}
             {isAuthenticated ? (
               <div className="flex items-center gap-2">
-                <Link
-                  href={adminLink.href}
-                  className={cn(
-                    "group/admin inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-4 py-2 text-sm font-medium shadow-[inset_0_1px_0_theme(colors.white/10)] transition-all duration-300 hover:-translate-y-0.5 hover:border-amber-400/30 hover:bg-amber-500/5",
-                    pathname.startsWith("/dashboard") &&
-                      "border-amber-400/30 bg-amber-500/5 text-primary",
-                  )}
-                >
-                  <AdminIcon className={cn(
-                    "size-4 transition-transform duration-300 group-hover/admin:scale-110",
-                    pathname.startsWith("/dashboard") ? "text-primary" : adminLink.color
-                  )} />
-                  {adminLink.label}
-                  <Crown className="ml-1 size-3 text-amber-400 opacity-60 transition-opacity duration-300 group-hover/admin:opacity-100" />
-                </Link>
+                {isAdmin && (
+                  <Link
+                    href={adminLink.href}
+                    className={cn(
+                      "group/admin inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-4 py-2 text-sm font-medium shadow-[inset_0_1px_0_theme(colors.white/10)] transition-all duration-300 hover:-translate-y-0.5 hover:border-amber-400/30 hover:bg-amber-500/5",
+                      pathname.startsWith("/dashboard") &&
+                        "border-amber-400/30 bg-amber-500/5 text-primary",
+                    )}
+                  >
+                    <AdminIcon
+                      className={cn(
+                        "size-4 transition-transform duration-300 group-hover/admin:scale-110",
+                        pathname.startsWith("/dashboard") ? "text-primary" : adminLink.color
+                      )}
+                    />
+                    {adminLink.label}
+                    <Crown className="ml-1 size-3 text-amber-400 opacity-60 transition-opacity duration-300 group-hover/admin:opacity-100" />
+                  </Link>
+                )}
 
                 {/* Dropdown do Usuário */}
                 <div className="relative">
@@ -358,22 +363,26 @@ export function Navbar({ user }: NavbarProps) {
                     </div>
                   </div>
 
-                  <Link
-                    href={adminLink.href}
-                    onClick={closeMobileMenu}
-                    className={cn(
-                      "group/admin flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3 text-base font-medium shadow-[inset_0_1px_0_theme(colors.white/10)] transition-all duration-300 hover:border-primary/30 hover:bg-primary/5",
-                      pathname.startsWith("/dashboard") &&
-                        "border-primary/30 bg-primary/5 text-primary",
-                    )}
-                  >
-                    <AdminIcon className={cn(
-                      "size-5",
-                      pathname.startsWith("/dashboard") ? "text-primary" : adminLink.color
-                    )} />
-                    <span className="flex-1">{adminLink.label}</span>
-                    <Crown className="size-4 text-amber-400 opacity-60" />
-                  </Link>
+                  {isAdmin && (
+                    <Link
+                      href={adminLink.href}
+                      onClick={closeMobileMenu}
+                      className={cn(
+                        "group/admin flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3 text-base font-medium shadow-[inset_0_1px_0_theme(colors.white/10)] transition-all duration-300 hover:border-primary/30 hover:bg-primary/5",
+                        pathname.startsWith("/dashboard") &&
+                          "border-primary/30 bg-primary/5 text-primary",
+                      )}
+                    >
+                      <AdminIcon
+                        className={cn(
+                          "size-5",
+                          pathname.startsWith("/dashboard") ? "text-primary" : adminLink.color
+                        )}
+                      />
+                      <span className="flex-1">{adminLink.label}</span>
+                      <Crown className="size-4 text-amber-400 opacity-60" />
+                    </Link>
+                  )}
 
                   <button
                     type="button"

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -37,8 +37,11 @@ export const {
         let user = null;
         try {
           user = await prisma.user.findUnique({ where: { username } });
-        } catch {
-          return null;
+        } catch (dbError) {
+          console.error("Erro ao consultar usuário no banco de dados", dbError);
+          const error = new CredentialsSignin("Não foi possível validar suas credenciais no momento.");
+          error.code = "database_error";
+          throw error;
         }
 
         if (!user) {
@@ -47,7 +50,16 @@ export const {
           throw error;
         }
 
-        const ok = await verifyPassword(password, user.passwordHash);
+        let ok = false;
+        try {
+          ok = await verifyPassword(password, user.passwordHash);
+        } catch (verificationError) {
+          console.error("Erro ao verificar senha do usuário", verificationError);
+          const error = new CredentialsSignin("Não foi possível validar suas credenciais no momento.");
+          error.code = "verification_error";
+          throw error;
+        }
+
         if (!ok) {
           const error = new CredentialsSignin("Senha incorreta");
           error.code = "invalid_password";


### PR DESCRIPTION
## Summary
- hide the admin panel shortcut in the navbar for non-admin sessions
- add specific credential error handling on the login screen with clearer messaging and accessibility
- surface database and password verification failures from the credentials provider with dedicated error codes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b68593f48333826ec23b004ea29e