### PR TITLE
Add user favorites support for destinations

### DIFF
--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -1,0 +1,203 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { serializeDestination } from "@/lib/destinations";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const bodySchema = z.object({
+  destinationId: z.coerce.number().int().positive(),
+});
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, { status });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return jsonResponse(
+      {
+        status: "error",
+        message: "É necessário estar autenticado para favoritar destinos.",
+      },
+      401
+    );
+  }
+
+  let parsedBody: z.infer<typeof bodySchema>;
+  try {
+    const body = await request.json();
+    const result = bodySchema.safeParse(body);
+    if (!result.success) {
+      return jsonResponse(
+        {
+          status: "error",
+          message: "Dados inválidos enviados para favoritar o destino.",
+          errors: result.error.flatten().fieldErrors,
+        },
+        400
+      );
+    }
+    parsedBody = result.data;
+  } catch {
+    return jsonResponse(
+      {
+        status: "error",
+        message: "Não foi possível ler os dados enviados.",
+      },
+      400
+    );
+  }
+
+  const userId = Number(session.user.id);
+  const { destinationId } = parsedBody;
+
+  try {
+    const destination = await prisma.destination.findUnique({
+      where: { id: destinationId },
+    });
+
+    if (!destination) {
+      return jsonResponse(
+        {
+          status: "error",
+          message: "Destino não encontrado.",
+        },
+        404
+      );
+    }
+
+    const existingFavorite = await prisma.favorite.findUnique({
+      where: {
+        userId_destinationId: {
+          userId,
+          destinationId,
+        },
+      },
+    });
+
+    const favorite =
+      existingFavorite ??
+      (await prisma.favorite.create({
+        data: {
+          userId,
+          destinationId,
+        },
+      }));
+
+    const serializedDestination = {
+      ...serializeDestination(destination),
+      isFavorite: true,
+      favoriteCreatedAt: favorite.createdAt.toISOString(),
+    };
+
+    return jsonResponse({
+      status: "success",
+      destination: serializedDestination,
+    });
+  } catch (error) {
+    console.error("Erro ao favoritar destino", error);
+    return jsonResponse(
+      {
+        status: "error",
+        message: "Não foi possível adicionar o destino aos favoritos.",
+      },
+      500
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return jsonResponse(
+      {
+        status: "error",
+        message: "É necessário estar autenticado para remover favoritos.",
+      },
+      401
+    );
+  }
+
+  let parsedBody: z.infer<typeof bodySchema>;
+  try {
+    const body = await request.json();
+    const result = bodySchema.safeParse(body);
+    if (!result.success) {
+      return jsonResponse(
+        {
+          status: "error",
+          message: "Dados inválidos enviados para remover o favorito.",
+          errors: result.error.flatten().fieldErrors,
+        },
+        400
+      );
+    }
+    parsedBody = result.data;
+  } catch {
+    return jsonResponse(
+      {
+        status: "error",
+        message: "Não foi possível ler os dados enviados.",
+      },
+      400
+    );
+  }
+
+  const userId = Number(session.user.id);
+  const { destinationId } = parsedBody;
+
+  try {
+    const destination = await prisma.destination.findUnique({
+      where: { id: destinationId },
+    });
+
+    if (!destination) {
+      return jsonResponse(
+        {
+          status: "error",
+          message: "Destino não encontrado.",
+        },
+        404
+      );
+    }
+
+    const existingFavorite = await prisma.favorite.findUnique({
+      where: {
+        userId_destinationId: {
+          userId,
+          destinationId,
+        },
+      },
+    });
+
+    if (existingFavorite) {
+      await prisma.favorite.delete({
+        where: { id: existingFavorite.id },
+      });
+    }
+
+    const serializedDestination = {
+      ...serializeDestination(destination),
+      isFavorite: false,
+      favoriteCreatedAt: null,
+    };
+
+    return jsonResponse({
+      status: "success",
+      destination: serializedDestination,
+    });
+  } catch (error) {
+    console.error("Erro ao remover favorito", error);
+    return jsonResponse(
+      {
+        status: "error",
+        message: "Não foi possível remover o destino dos favoritos.",
+      },
+      500
+    );
+  }
+}

--- a/app/destinos/page.tsx
+++ b/app/destinos/page.tsx
@@ -109,12 +109,28 @@ export default async function DestinationsPage() {
 
   let destinations: SerializedDestination[] = [];
   let destinationsError = false;
+  const favoriteDestinationIds = new Set<number>();
+
+  if (session?.user?.id) {
+    try {
+      const favorites = await prisma.favorite.findMany({
+        where: { userId: Number(session.user.id) },
+        select: { destinationId: true },
+      });
+      favorites.forEach((favorite) => favoriteDestinationIds.add(favorite.destinationId));
+    } catch (error) {
+      console.error("Erro ao buscar favoritos do usuário", error);
+    }
+  }
   try {
     // Busca todos os destinos ordenados por data de criação.
     const destinationsFromDb = await prisma.destination.findMany({
       orderBy: { createdAt: "desc" },
     });
-    destinations = destinationsFromDb.map(serializeDestination);
+    destinations = destinationsFromDb.map((destination) => ({
+      ...serializeDestination(destination),
+      isFavorite: favoriteDestinationIds.has(destination.id),
+    }));
   } catch (error) {
     console.error("Erro ao buscar destinos", error);
     destinationsError = true;
@@ -293,6 +309,7 @@ export default async function DestinationsPage() {
               ) : (
                 <DestinationGrid
                   destinations={destinations}
+                  canFavorite={Boolean(session?.user?.id)}
                   onDelete={session?.user ? deleteDestination : undefined}
                 />
               )}

--- a/app/favoritos/page.tsx
+++ b/app/favoritos/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from "next/navigation";
+
+import { FavoritesGrid } from "@/components/favorites/favorites-grid";
+import { auth } from "@/lib/auth";
+import { serializeDestination, type SerializedDestination } from "@/lib/destinations";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+export default async function FavoritesPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect(`/login?callbackUrl=${encodeURIComponent("/favoritos")}`);
+  }
+
+  const userId = Number(session.user.id);
+
+  let favoriteDestinations: SerializedDestination[] = [];
+  try {
+    const favorites = await prisma.favorite.findMany({
+      where: { userId },
+      include: { destination: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    favoriteDestinations = favorites
+      .filter((favorite) => favorite.destination)
+      .map((favorite) => ({
+        ...serializeDestination(favorite.destination),
+        isFavorite: true,
+        favoriteCreatedAt: favorite.createdAt.toISOString(),
+      }));
+  } catch (error) {
+    console.error("Erro ao carregar favoritos", error);
+  }
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-pink-50 via-white to-sky-50">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-20 left-10 h-80 w-80 rounded-full bg-pink-300/30 blur-3xl" />
+        <div className="absolute bottom-10 right-20 h-96 w-96 rounded-full bg-cyan-300/25 blur-3xl" />
+        <div className="absolute left-1/3 top-1/2 h-72 w-72 rounded-full bg-purple-300/20 blur-3xl" />
+      </div>
+
+      <section className="relative z-10 mx-auto max-w-7xl px-4 pb-16 pt-24 sm:px-6 lg:px-8">
+        <div className="rounded-3xl border border-white/20 bg-white/80 p-6 shadow-2xl backdrop-blur-xl transition hover:shadow-3xl sm:p-10">
+          <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-4">
+              <div className="inline-flex items-center gap-2 rounded-full border border-pink-400/40 bg-pink-400/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-pink-500 shadow-sm">
+                <span className="inline-flex size-2 rounded-full bg-pink-500" />
+                <span>Favoritos</span>
+                <span className="inline-flex size-2 rounded-full bg-pink-500" />
+              </div>
+              <h1 className="text-balance text-3xl font-bold text-slate-900 sm:text-4xl">
+                Seus destinos inesquecíveis
+              </h1>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-600 sm:text-base">
+                Organize os lugares que você mais gostou e planeje sua próxima viagem com praticidade. Remova destinos quando mudar de ideia e mantenha sua lista sempre atualizada.
+              </p>
+            </div>
+          </header>
+
+          <div className="mt-10">
+            <FavoritesGrid initialDestinations={favoriteDestinations} />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 
 import { Navbar } from "@/components/navbar";
+import { Toaster } from "@/components/ui/sonner";
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
 import "./globals.css";
 
@@ -19,12 +21,24 @@ export default async function RootLayout({
 }) {
   // Recupera a sessão para passar o usuário autenticado ao componente Navbar.
   const session = await auth();
+  let favoriteCount = 0;
+
+  if (session?.user?.id) {
+    try {
+      favoriteCount = await prisma.favorite.count({
+        where: { userId: Number(session.user.id) },
+      });
+    } catch (error) {
+      console.error("Erro ao contar favoritos do usuário", error);
+    }
+  }
 
   return (
     <html lang="pt-BR">
       <body className="font-sans antialiased">
-        <Navbar user={session?.user ?? null} />
+        <Navbar user={session?.user ?? null} favoriteCount={favoriteCount} />
         <div className="pt-20 lg:pt-24">{children}</div>
+        <Toaster richColors closeButton position="top-right" />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,12 +46,29 @@ export default async function HomePage() {
 
   // 2) Destinos (igual, sem mexer no backend)
   let destinations: SerializedDestination[] = [];
+  const favoriteDestinationIds = new Set<number>();
+
+  if (session?.user?.id) {
+    try {
+      const favorites = await prisma.favorite.findMany({
+        where: { userId: Number(session.user.id) },
+        select: { destinationId: true },
+      });
+      favorites.forEach((favorite) => favoriteDestinationIds.add(favorite.destinationId));
+    } catch (error) {
+      console.error("Erro ao buscar favoritos do usuário", error);
+    }
+  }
+
   try {
     const destinationsFromDb = await prisma.destination.findMany({
       orderBy: { createdAt: "desc" },
       take: 12,
     });
-    destinations = destinationsFromDb.map(serializeDestination);
+    destinations = destinationsFromDb.map((destination) => ({
+      ...serializeDestination(destination),
+      isFavorite: favoriteDestinationIds.has(destination.id),
+    }));
   } catch {
     destinations = [];
   }
@@ -183,7 +200,10 @@ export default async function HomePage() {
 
             {/* Grid de destinos (sem mudar a API/props) */}
             <div className="mt-6 sm:mt-8 md:mt-10">
-              <DestinationGrid destinations={destinations} />
+              <DestinationGrid
+                destinations={destinations}
+                canFavorite={Boolean(session?.user?.id)}
+              />
             </div>
           </div>
         </div>

--- a/components/destinations/destination-card.tsx
+++ b/components/destinations/destination-card.tsx
@@ -32,18 +32,25 @@ import { buttonVariants } from "@/components/ui/button";
 import type { SerializedDestination } from "@/lib/destinations";
 import { cn } from "@/lib/utils";
 
+import { FavoriteButton } from "./favorite-button";
+
 interface DestinationCardProps {
   destination: SerializedDestination;
   fullHeight?: boolean;
+  canFavorite?: boolean;
+  onFavoriteChange?: (destinationId: number, isFavorite: boolean) => void;
 }
 
 export function DestinationCard({
   destination,
   fullHeight = true,
+  canFavorite = true,
+  onFavoriteChange,
 }: DestinationCardProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   const photos = destination.photos.length > 0 ? destination.photos : ["/placeholder.jpg"];
+  const initialFavorite = Boolean(destination.isFavorite);
 
   const priceFormatter = useMemo(
     () =>
@@ -97,6 +104,16 @@ export function DestinationCard({
 
           <CardHeader className="gap-4 min-w-0">
             <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-white/60 bg-slate-100 shadow-inner">
+              <div className="absolute right-3 top-3 z-10">
+                <FavoriteButton
+                  destinationId={destination.id}
+                  initialIsFavorite={initialFavorite}
+                  canFavorite={canFavorite}
+                  onStatusChange={(isFavorite) =>
+                    onFavoriteChange?.(destination.id, isFavorite)
+                  }
+                />
+              </div>
               <Image
                 src={photos[activeIndex]}
                 alt={destination.name}

--- a/components/destinations/destination-grid.tsx
+++ b/components/destinations/destination-grid.tsx
@@ -11,9 +11,14 @@ import { ManageableDestinationCard } from "./manageable-destination-card";
 interface DestinationGridProps {
   destinations: SerializedDestination[];
   onDelete?: DestinationDeleteAction;
+  canFavorite?: boolean;
 }
 
-export function DestinationGrid({ destinations, onDelete }: DestinationGridProps) {
+export function DestinationGrid({
+  destinations,
+  onDelete,
+  canFavorite = true,
+}: DestinationGridProps) {
   if (destinations.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-200 bg-white/80 p-12 text-center shadow-lg">
@@ -40,9 +45,14 @@ export function DestinationGrid({ destinations, onDelete }: DestinationGridProps
             key={destination.id}
             destination={destination}
             action={onDelete}
+            canFavorite={canFavorite}
           />
         ) : (
-          <DestinationCard key={destination.id} destination={destination} />
+          <DestinationCard
+            key={destination.id}
+            destination={destination}
+            canFavorite={canFavorite}
+          />
         )
       )}
     </div>

--- a/components/destinations/favorite-button.tsx
+++ b/components/destinations/favorite-button.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { type MouseEvent, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Heart } from "lucide-react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+
+interface FavoriteButtonProps {
+  destinationId: number;
+  initialIsFavorite: boolean;
+  canFavorite: boolean;
+  onStatusChange?: (isFavorite: boolean) => void;
+}
+
+export function FavoriteButton({
+  destinationId,
+  initialIsFavorite,
+  canFavorite,
+  onStatusChange,
+}: FavoriteButtonProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [isFavorite, setIsFavorite] = useState(initialIsFavorite);
+  const [optimisticFavorite, setOptimisticFavorite] = useState(initialIsFavorite);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    setIsFavorite(initialIsFavorite);
+    setOptimisticFavorite(initialIsFavorite);
+  }, [initialIsFavorite]);
+
+  const tooltipLabel = useMemo(
+    () => (optimisticFavorite ? "Remover dos Favoritos" : "Adicionar aos Favoritos"),
+    [optimisticFavorite]
+  );
+
+  const buildLoginRedirect = () => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    const query = params.toString();
+    const callbackUrl = query ? `${pathname}?${query}` : pathname;
+    return `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  };
+
+  const handleUnauthorized = () => {
+    toast.info("Entre na sua conta para gerenciar favoritos.");
+    router.push(buildLoginRedirect());
+  };
+
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    if (!canFavorite) {
+      handleUnauthorized();
+      return;
+    }
+
+    const nextState = !optimisticFavorite;
+    setOptimisticFavorite(nextState);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/favorites", {
+        method: nextState ? "POST" : "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ destinationId }),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | { status?: string; message?: string; destination?: { isFavorite?: boolean | null } }
+        | null;
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          handleUnauthorized();
+        } else {
+          toast.error(data?.message ?? "Não foi possível atualizar seus favoritos.");
+        }
+        setOptimisticFavorite(isFavorite);
+        return;
+      }
+
+      const serverState = data?.destination?.isFavorite ?? nextState;
+      setIsFavorite(Boolean(serverState));
+      setOptimisticFavorite(Boolean(serverState));
+      onStatusChange?.(Boolean(serverState));
+
+      toast.success(
+        Boolean(serverState)
+          ? "Destino adicionado aos favoritos!"
+          : "Destino removido dos favoritos."
+      );
+      router.refresh();
+    } catch (error) {
+      console.error("Erro ao atualizar favorito", error);
+      setOptimisticFavorite(isFavorite);
+      toast.error("Não foi possível atualizar seus favoritos.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "group/favorite relative inline-flex h-10 w-10 items-center justify-center rounded-full border bg-white/85 text-slate-500 shadow-lg shadow-slate-900/5 transition",
+        "hover:-translate-y-0.5 hover:border-pink-500/40 hover:bg-pink-500/15 hover:text-pink-500",
+        optimisticFavorite &&
+          "border-pink-500/40 bg-pink-500/15 text-pink-500 hover:bg-pink-500/20",
+        isSubmitting && "pointer-events-none opacity-70"
+      )}
+      onClick={handleClick}
+      onPointerDown={(event) => event.stopPropagation()}
+      aria-pressed={optimisticFavorite}
+      aria-label={tooltipLabel}
+      title={tooltipLabel}
+    >
+      <Heart
+        className={cn(
+          "size-5 transition-transform duration-300",
+          optimisticFavorite
+            ? "scale-110 fill-current text-pink-500 drop-shadow-[0_0_10px_rgba(236,72,153,0.35)]"
+            : "text-slate-500"
+        )}
+      />
+      <span className="sr-only">{tooltipLabel}</span>
+    </button>
+  );
+}

--- a/components/destinations/manageable-destination-card.tsx
+++ b/components/destinations/manageable-destination-card.tsx
@@ -15,11 +15,13 @@ import { DestinationCard } from "./destination-card";
 interface ManageableDestinationCardProps {
   destination: SerializedDestination;
   action: DestinationDeleteAction;
+  canFavorite?: boolean;
 }
 
 export function ManageableDestinationCard({
   destination,
   action,
+  canFavorite = true,
 }: ManageableDestinationCardProps) {
   const [state, formAction, isPending] = useActionState(
     action,
@@ -28,7 +30,11 @@ export function ManageableDestinationCard({
 
   return (
     <div className="space-y-4">
-      <DestinationCard destination={destination} fullHeight={false} />
+      <DestinationCard
+        destination={destination}
+        fullHeight={false}
+        canFavorite={canFavorite}
+      />
       <form
         action={formAction}
         className="flex flex-col gap-3 rounded-2xl border border-red-100/60 bg-white/80 p-4 shadow-md transition-colors hover:border-red-200 sm:flex-row sm:items-center sm:justify-between"

--- a/components/favorites/favorites-grid.tsx
+++ b/components/favorites/favorites-grid.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Heart, Compass } from "lucide-react";
+
+import { DestinationCard } from "@/components/destinations/destination-card";
+import { buttonVariants } from "@/components/ui/button";
+import type { SerializedDestination } from "@/lib/destinations";
+import { cn } from "@/lib/utils";
+
+interface FavoritesGridProps {
+  initialDestinations: SerializedDestination[];
+}
+
+export function FavoritesGrid({ initialDestinations }: FavoritesGridProps) {
+  const [favorites, setFavorites] = useState(initialDestinations);
+
+  const handleFavoriteChange = (destinationId: number, isFavorite: boolean) => {
+    if (!isFavorite) {
+      setFavorites((current) =>
+        current.filter((destination) => destination.id !== destinationId)
+      );
+    }
+  };
+
+  if (favorites.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-dashed border-pink-300/60 bg-white/80 p-12 text-center shadow-lg">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-pink-500/15 text-pink-500 shadow-inner">
+          <Heart className="h-10 w-10" />
+        </div>
+        <div className="space-y-3">
+          <h2 className="text-2xl font-semibold text-slate-900">Você ainda não tem favoritos</h2>
+          <p className="text-sm text-slate-600">
+            Explore os destinos disponíveis e toque no coração para salvar as experiências que mais combinam com você.
+          </p>
+        </div>
+        <Link
+          href="/destinos"
+          className={cn(
+            buttonVariants({ variant: "default" }),
+            "rounded-full bg-pink-500/90 px-6 py-2 text-white shadow-md transition hover:bg-pink-500"
+          )}
+        >
+          Explorar destinos
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
+      <AnimatePresence mode="popLayout">
+        {favorites.map((destination) => (
+          <motion.div
+            key={destination.id}
+            layout
+            initial={{ opacity: 0, scale: 0.97 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.94 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="will-change-transform"
+          >
+            <DestinationCard
+              destination={{ ...destination, isFavorite: true }}
+              onFavoriteChange={handleFavoriteChange}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+      <motion.div
+        layout
+        key="cta"
+        className="hidden items-center justify-center rounded-3xl border border-slate-200/60 bg-gradient-to-br from-white/80 to-white/60 p-6 text-center shadow-inner shadow-slate-200/50 sm:flex"
+      >
+        <div className="space-y-3">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-500/10 text-blue-500">
+            <Compass className="h-6 w-6" />
+          </div>
+          <p className="text-sm text-slate-600">
+            Continue explorando para aumentar sua coleção de destinos favoritos.
+          </p>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -17,33 +17,61 @@ import {
   Menu,
   X,
   ChevronDown,
-  BookmarkIcon,
+  Heart,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
 import { cn } from "@/lib/utils";
 
+type NavLink = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  color: string;
+  badge?: string;
+};
+
 interface NavbarProps {
   user: Session["user"] | null;
+  favoriteCount?: number;
 }
 
-export function Navbar({ user }: NavbarProps) {
+export function Navbar({ user, favoriteCount: favoriteCountProp = 0 }: NavbarProps) {
   const pathname = usePathname();
   const isAuthenticated = Boolean(user);
   const isAdmin = user?.role === "admin";
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
+  const favoriteCountValue = Number.isFinite(favoriteCountProp)
+    ? Math.max(0, Math.floor(favoriteCountProp))
+    : 0;
+  const favoriteBadgeLabel = favoriteCountValue > 99 ? "99+" : `${favoriteCountValue}`;
+  const hasFavorites = favoriteCountValue > 0;
+
   const handleSignOut = () => {
     void signOut({ redirectTo: "/" });
   };
 
-  const primaryLinks = [
+  const baseLinks: NavLink[] = [
     { href: "/", label: "Início", icon: Home, color: "text-blue-400" },
     { href: "/destinos", label: "Destinos", icon: MapPin, color: "text-emerald-400" },
     { href: "/sobre-nos", label: "Sobre nós", icon: Info, color: "text-purple-400" },
   ];
+
+  const favoritesLink: NavLink | null = isAuthenticated
+    ? {
+        href: "/favoritos",
+        label: "Favoritos",
+        icon: Heart,
+        color: "text-pink-400",
+        badge: hasFavorites ? favoriteBadgeLabel : undefined,
+      }
+    : null;
+
+  const navigationLinks = favoritesLink ? [...baseLinks, favoritesLink] : baseLinks;
 
   const userDisplayName = user?.name?.trim() ? user.name : "Usuário";
   const userFirstName = userDisplayName.split(" ")[0];
@@ -124,7 +152,7 @@ export function Navbar({ user }: NavbarProps) {
           {/* DESKTOP NAV */}
           <nav className="hidden flex-1 items-center justify-end gap-2 lg:flex lg:gap-3">
             <div className="flex items-center gap-1">
-              {primaryLinks.map(({ href, label, icon: Icon, color }) => {
+              {navigationLinks.map(({ href, label, icon: Icon, color, badge }) => {
                 const isActive =
                   pathname === href || pathname.startsWith(href + "/");
                 return (
@@ -148,7 +176,14 @@ export function Navbar({ user }: NavbarProps) {
                         isActive ? "text-primary" : color,
                       )}
                     />
-                    <span>{label}</span>
+                    <span className="flex items-center gap-1">
+                      {label}
+                      {badge ? (
+                        <span className="inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-pink-500/20 px-2 py-0.5 text-[0.65rem] font-semibold text-pink-600 shadow-sm">
+                          {badge}
+                        </span>
+                      ) : null}
+                    </span>
                     <span
                       className={cn(
                         "pointer-events-none absolute -bottom-px left-1/2 h-[2px] w-0 -translate-x-1/2 rounded bg-primary/70 transition-all duration-500 group-hover/nav:w-4/5",
@@ -235,6 +270,19 @@ export function Navbar({ user }: NavbarProps) {
                             <User className="size-4 text-cyan-400" />
                             Meu Perfil
                           </Link>
+                          <Link
+                            href="/favoritos"
+                            onClick={closeUserMenu}
+                            className="mt-1 flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors hover:bg-white/5"
+                          >
+                            <Heart className="size-4 text-pink-400" />
+                            Favoritos
+                            {hasFavorites ? (
+                              <span className="ml-auto inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-pink-500/20 px-2 py-0.5 text-[0.65rem] font-semibold text-pink-600 shadow-sm">
+                                {favoriteBadgeLabel}
+                              </span>
+                            ) : null}
+                          </Link>
                         </div>
                       </div>
                     </>
@@ -292,7 +340,7 @@ export function Navbar({ user }: NavbarProps) {
         >
           <nav className="border-t border-white/10 bg-background/95 px-4 py-4 backdrop-blur-xl">
             <div className="flex flex-col gap-2">
-              {primaryLinks.map(({ href, label, icon: Icon, color }) => {
+              {navigationLinks.map(({ href, label, icon: Icon, color, badge }) => {
                 const isActive =
                   pathname === href || pathname.startsWith(href + "/");
                 return (
@@ -311,7 +359,14 @@ export function Navbar({ user }: NavbarProps) {
                         isActive ? "text-primary" : color,
                       )}
                     />
-                    <span>{label}</span>
+                    <span className="flex items-center gap-1">
+                      {label}
+                      {badge ? (
+                        <span className="inline-flex min-w-[1.6rem] items-center justify-center rounded-full bg-pink-500/20 px-2 py-0.5 text-[0.7rem] font-semibold text-pink-600 shadow-sm">
+                          {badge}
+                        </span>
+                      ) : null}
+                    </span>
                   </Link>
                 );
               })}
@@ -353,12 +408,19 @@ export function Navbar({ user }: NavbarProps) {
                         Meu Perfil
                       </Link>
                       <Link
-                        href="/usuario/favoritos"
+                        href="/favoritos"
                         onClick={closeMobileMenu}
                         className="flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors hover:bg-white/5"
                       >
-                        <BookmarkIcon className="size-4 text-pink-400" />
-                        Favoritos
+                        <Heart className="size-4 text-pink-400" />
+                        <span className="flex items-center gap-2">
+                          Favoritos
+                          {hasFavorites ? (
+                            <span className="inline-flex min-w-[1.6rem] items-center justify-center rounded-full bg-pink-500/20 px-2 py-0.5 text-[0.7rem] font-semibold text-pink-600 shadow-sm">
+                              {favoriteBadgeLabel}
+                            </span>
+                          ) : null}
+                        </span>
                       </Link>
                     </div>
                   </div>

--- a/lib/destinations.ts
+++ b/lib/destinations.ts
@@ -99,6 +99,8 @@ export type SerializedDestination = {
   photos: string[];
   createdAt: string;
   updatedAt: string;
+  isFavorite?: boolean;
+  favoriteCreatedAt?: string | null;
 };
 
 export function serializeDestination(

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const protectedMatchers = ["/dashboard", "/api/profile", "/usuario"];
+const protectedMatchers = [
+  "/dashboard",
+  "/api/profile",
+  "/usuario",
+  "/favoritos",
+  "/api/favorites",
+];
 
 async function isAuthenticated(request: NextRequest) {
   try {
@@ -38,5 +44,11 @@ export default async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/api/profile/:path*", "/usuario/:path*"],
+  matcher: [
+    "/dashboard/:path*",
+    "/api/profile/:path*",
+    "/usuario/:path*",
+    "/favoritos",
+    "/api/favorites/:path*",
+  ],
 };

--- a/prisma/migrations/20250212123456_add_favorites/migration.sql
+++ b/prisma/migrations/20250212123456_add_favorites/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Favorite" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "destinationId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Favorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Favorite_userId_destinationId_key" ON "Favorite"("userId", "destinationId");
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_destinationId_fkey" FOREIGN KEY ("destinationId") REFERENCES "Destination"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   destinations Destination[]
+  favorites    Favorite[]
 }
 
 enum BackgroundDisplayMode {
@@ -64,4 +65,18 @@ model Destination {
 
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int
+
+  favorites Favorite[]
+}
+
+model Favorite {
+  id            Int          @id @default(autoincrement())
+  userId        Int
+  destinationId Int
+  createdAt     DateTime     @default(now())
+
+  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  destination Destination @relation(fields: [destinationId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, destinationId])
 }


### PR DESCRIPTION
## Summary
- add a Favorite Prisma model and migration to persist user favorites with timestamps
- expose REST endpoints plus optimistic favorite toggles on destination cards and navigation badge updates
- add an authenticated /favoritos page with a responsive grid that reuses destination cards and empty-state messaging

## Testing
- npm run lint
- npx prisma migrate dev --name add-favorites *(fails: Can't reach database server at `ep-round-bar-ad8oa2bi-pooler.c-2.us-east-1.aws.neon.tech:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ca67d00c8333a121c923bb155739