### PR TITLE
Enhance authentication page layouts

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -37,6 +37,12 @@ const ERROR_MESSAGES: Record<string, string> = {
 const DEFAULT_ERROR_MESSAGE =
   "Não foi possível entrar. Confira suas credenciais e tente novamente.";
 
+const loginHighlights = [
+  "Planeje viagens personalizadas",
+  "Descontos especiais para clientes",
+  "Suporte humano 24/7",
+];
+
 export default function LoginPage() {
   // Navegação / callback (mesmo backend)
   const router = useRouter();
@@ -142,155 +148,207 @@ export default function LoginPage() {
 
       {/* Container central */}
       <section className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-7xl items-center justify-center px-4 sm:px-6 lg:px-8">
-        {/* Card de login — glass, borda suave, sombras leves */}
-        <div className="group relative w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-2xl backdrop-blur-xl transition-all duration-500 sm:p-8">
-          {/* Glow no hover (mesma linguagem visual) */}
+        {/* Card de login com layout responsivo */}
+        <div className="group relative w-full max-w-5xl overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/80 shadow-2xl backdrop-blur-2xl transition-all duration-500">
           <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-cyan-500/5" />
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-cyan-500/10" />
           </div>
 
-          {/* Título e subtítulo */}
-          <div className="mb-6 text-center">
-            <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full border border-slate-200/60 bg-white/60 px-4 py-1.5 text-xs font-semibold text-slate-700">
-              <Sparkles className="h-4 w-4 text-blue-600" />
-              Acesso seguro Evastur
+          <div className="relative grid gap-0 lg:grid-cols-[1.05fr_1fr]">
+            {/* Coluna inspiracional (desktop) */}
+            <div className="relative hidden flex-col justify-between overflow-hidden bg-gradient-to-br from-blue-700 via-blue-600 to-cyan-500 p-10 text-white lg:flex">
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide">
+                  <Sparkles className="h-4 w-4" />
+                  Bem-vindo a bordo
+                </div>
+                <h2 className="mt-6 text-3xl font-semibold leading-tight">
+                  Simplifique seus próximos destinos com a Evastur
+                </h2>
+                <p className="mt-4 max-w-sm text-sm text-blue-50/90">
+                  Acesse sua conta para gerenciar roteiros, favoritos e acompanhar as novidades exclusivas da nossa equipe de especialistas.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                {loginHighlights.map((feature) => (
+                  <div key={feature} className="flex items-center gap-3 text-sm text-blue-50">
+                    <div className="grid h-9 w-9 place-items-center rounded-full bg-white/15 shadow-inner">
+                      <Plane className="h-4 w-4" />
+                    </div>
+                    <span>{feature}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-8 flex items-center gap-3 text-xs text-blue-50/80">
+                <div className="h-10 w-10 rounded-full bg-white/20" />
+                <div>
+                  <p className="font-semibold">Equipe Evastur</p>
+                  <p>Mais de 20 anos transformando experiências de viagem.</p>
+                </div>
+              </div>
+
+              <div className="pointer-events-none absolute -right-24 -top-16 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
+              <div className="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-cyan-400/40 blur-3xl" />
             </div>
-            <h2 className="text-2xl font-bold text-slate-900">Entrar</h2>
-            <p className="mt-1 text-sm text-slate-600">Use seu usuário e senha para continuar.</p>
-          </div>
 
-          {/* feedbacks */}
-          <AnimatePresence mode="wait">
-            {error && (
-              <motion.div
-                key="login-error"
-                initial={fieldMotion.initial}
-                animate={fieldMotion.animate}
-                exit={fieldMotion.exit}
-                transition={fieldTransition}
-                role="alert"
-                aria-live="assertive"
-                className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-              >
-                <AlertCircle className="h-4 w-4" />
-                <span>{error}</span>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <AnimatePresence mode="wait">
-            {success && (
-              <motion.div
-                key="login-success"
-                initial={fieldMotion.initial}
-                animate={fieldMotion.animate}
-                exit={fieldMotion.exit}
-                transition={fieldTransition}
-                role="status"
-                aria-live="polite"
-                className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
-              >
-                <CheckCircle2 className="h-4 w-4" />
-                <span>{success}</span>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* Formulário (fluxo idêntico ao seu) */}
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="username" className="text-sm font-medium text-slate-800">
-                Usuário
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <UserRound className="h-4 w-4" />
-                </span>
-                <input
-                  id="username"
-                  name="username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  autoComplete="username"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
+            {/* Conteúdo do formulário */}
+            <div className="relative flex flex-col justify-center p-6 sm:p-8 lg:p-10">
+              {/* Título mobile */}
+              <div className="mb-8 text-center lg:hidden">
+                <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full border border-slate-200/60 bg-white/60 px-4 py-1.5 text-xs font-semibold text-slate-700">
+                  <Sparkles className="h-4 w-4 text-blue-600" />
+                  Acesso seguro Evastur
+                </div>
+                <h2 className="text-3xl font-bold text-slate-900">Entrar</h2>
+                <p className="mt-2 text-sm text-slate-600">Use seu usuário e senha para continuar.</p>
               </div>
-            </motion.div>
 
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="password" className="text-sm font-medium text-slate-800">
-                Senha
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <LockKeyhole className="h-4 w-4" />
-                </span>
-                <input
-                  id="password"
-                  name="password"
-                  type={showPass ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete="current-password"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
-                <button
-                  type="button"
-                  aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
-                  onClick={() => setShowPass((v) => !v)}
-                  className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
+              {/* Título desktop */}
+              <div className="mb-8 hidden text-left lg:block">
+                <div className="inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50/60 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                  <Sparkles className="h-4 w-4" />
+                  Área do cliente
+                </div>
+                <h2 className="mt-4 text-3xl font-bold text-slate-900">Faça login na sua conta</h2>
+                <p className="mt-2 text-sm text-slate-600">Continue explorando destinos incríveis com a Evastur.</p>
+              </div>
+
+              {/* feedbacks */}
+              <AnimatePresence mode="wait">
+                {error && (
+                  <motion.div
+                    key="login-error"
+                    initial={fieldMotion.initial}
+                    animate={fieldMotion.animate}
+                    exit={fieldMotion.exit}
+                    transition={fieldTransition}
+                    role="alert"
+                    aria-live="assertive"
+                    className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  >
+                    <AlertCircle className="h-4 w-4" />
+                    <span>{error}</span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+              <AnimatePresence mode="wait">
+                {success && (
+                  <motion.div
+                    key="login-success"
+                    initial={fieldMotion.initial}
+                    animate={fieldMotion.animate}
+                    exit={fieldMotion.exit}
+                    transition={fieldTransition}
+                    role="status"
+                    aria-live="polite"
+                    className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    <span>{success}</span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              {/* Formulário (fluxo idêntico ao seu) */}
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
                 >
-                  {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
+                  <label htmlFor="username" className="text-sm font-medium text-slate-800">
+                    Usuário
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <UserRound className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="username"
+                      name="username"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      autoComplete="username"
+                      required
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                    />
+                  </div>
+                </motion.div>
+
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
+                >
+                  <label htmlFor="password" className="text-sm font-medium text-slate-800">
+                    Senha
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <LockKeyhole className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="password"
+                      name="password"
+                      type={showPass ? "text" : "password"}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      autoComplete="current-password"
+                      required
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                    />
+                    <button
+                      type="button"
+                      aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
+                      onClick={() => setShowPass((v) => !v)}
+                      className="absolute inset-y-0 right-0 grid w-12 place-items-center text-slate-500 transition hover:text-slate-700"
+                    >
+                      {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </motion.div>
+
+                <motion.button
+                  type="submit"
+                  disabled={loading}
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={{ ...fieldTransition, delay: 0.05 }}
+                  whileHover={{ translateY: loading ? 0 : -2 }}
+                  whileTap={{ scale: loading ? 1 : 0.98 }}
+                  className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {loading ? (
+                    <>
+                      <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                      Entrando...
+                    </>
+                  ) : (
+                    <>
+                      Entrar
+                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                    </>
+                  )}
+                </motion.button>
+              </form>
+
+              {/* Links auxiliares */}
+              <div className="mt-6 flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+                <Link href="/recuperar-senha" className="font-semibold text-blue-700 transition hover:text-blue-800">
+                  Esqueci minha senha
+                </Link>
+                <span className="text-center sm:text-right">
+                  Não tem conta?{" "}
+                  <Link href="/signup" className="font-semibold text-blue-700 transition hover:text-blue-800">
+                    Cadastre-se
+                  </Link>
+                </span>
               </div>
-            </motion.div>
-
-            <motion.button
-              type="submit"
-              disabled={loading}
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={{ ...fieldTransition, delay: 0.05 }}
-              whileHover={{ translateY: loading ? 0 : -2 }}
-              whileTap={{ scale: loading ? 1 : 0.98 }}
-              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {loading ? (
-                <>
-                  <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
-                  Entrando...
-                </>
-              ) : (
-                <>
-                  Entrar
-                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-                </>
-              )}
-            </motion.button>
-          </form>
-
-          {/* Links auxiliares */}
-          <div className="mt-5 flex items-center justify-between text-xs text-slate-600">
-            <Link href="/recuperar-senha" className="font-semibold text-blue-700 hover:underline">
-              Esqueci minha senha
-            </Link>
-            <span>
-              Não tem conta?{" "}
-              <Link href="/signup" className="font-semibold text-blue-700 hover:underline">
-                Cadastre-se
-              </Link>
-            </span>
+            </div>
           </div>
         </div>
       </section>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Sparkles,
-  Plane,
   Eye,
   EyeOff,
   AlertCircle,
@@ -29,6 +28,12 @@ const fieldMotion = {
   exit: { opacity: 0, y: -12 },
 };
 const fieldTransition = { duration: 0.32, ease: "easeOut" as const };
+
+const signupHighlights = [
+  "Crie perfis sob medida para sua equipe",
+  "Gerencie destinos favoritos em um só lugar",
+  "Receba novidades e ofertas exclusivas",
+];
 
 export default function SignupPage() {
   const router = useRouter();
@@ -172,331 +177,380 @@ export default function SignupPage() {
         <div className="absolute bottom-1/4 right-1/3 h-64 w-64 animate-pulse rounded-full bg-purple-500/15 blur-3xl" />
       </div>
 
-
       {/* container central */}
       <section className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-7xl items-center justify-center px-4 sm:px-6 lg:px-8">
         {/* card glass */}
-        <div className="group relative w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-2xl backdrop-blur-xl transition-all duration-500 sm:p-8">
-          {/* brilho sutil no hover */}
+        <div className="group relative w-full max-w-5xl overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/80 shadow-2xl backdrop-blur-2xl transition-all duration-500">
           <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-cyan-500/5" />
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-cyan-500/10" />
           </div>
 
-          {/* header do card */}
-          <div className="mb-6 text-center">
-            <div className="mx-auto mb-3 inline-grid h-14 w-14 place-items-center rounded-2xl border border-slate-200/60 bg-white/60 shadow">
-              <UserPlus className="h-7 w-7 text-blue-700" />
+          <div className="relative grid gap-0 lg:grid-cols-[1.05fr_1fr]">
+            {/* coluna inspiracional desktop */}
+            <div className="relative hidden flex-col justify-between overflow-hidden bg-gradient-to-br from-blue-700 via-blue-600 to-cyan-500 p-10 text-white lg:flex">
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide">
+                  <Sparkles className="h-4 w-4" />
+                  Comece sua jornada
+                </div>
+                <h2 className="mt-6 text-3xl font-semibold leading-tight">
+                  Cadastre-se para viver experiências inesquecíveis com a Evastur
+                </h2>
+                <p className="mt-4 max-w-sm text-sm text-blue-50/90">
+                  Tenha acesso a roteiros exclusivos, personalize destinos e mantenha toda a sua equipe alinhada em um painel intuitivo.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                {signupHighlights.map((feature) => (
+                  <div key={feature} className="flex items-center gap-3 text-sm text-blue-50">
+                    <div className="grid h-9 w-9 place-items-center rounded-full bg-white/15 shadow-inner">
+                      <ShieldCheck className="h-4 w-4" />
+                    </div>
+                    <span>{feature}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-8 flex items-center gap-3 text-xs text-blue-50/80">
+                <div className="h-10 w-10 rounded-full bg-white/20" />
+                <div>
+                  <p className="font-semibold">Equipe Evastur</p>
+                  <p>Transformando sonhos em viagens desde 1999.</p>
+                </div>
+              </div>
+
+              <div className="pointer-events-none absolute -right-24 -top-16 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
+              <div className="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-cyan-400/40 blur-3xl" />
             </div>
-            <h2 className="text-2xl font-bold text-slate-900">Criar conta</h2>
-            <p className="mt-1 text-sm text-slate-600">Cadastre um novo usuário para acessar a Evastur.</p>
-          </div>
 
-          {/* alertas */}
-          <AnimatePresence mode="wait">
-            {error && (
-              <motion.div
-                key="error"
-                initial={fieldMotion.initial}
-                animate={fieldMotion.animate}
-                exit={fieldMotion.exit}
-                transition={fieldTransition}
-                className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-              >
-                <AlertCircle className="h-4 w-4" />
-                <span>{error}</span>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <AnimatePresence mode="wait">
-            {success && (
-              <motion.div
-                key="success"
-                initial={fieldMotion.initial}
-                animate={fieldMotion.animate}
-                exit={fieldMotion.exit}
-                transition={fieldTransition}
-                className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
-              >
-                <CheckCircle2 className="h-4 w-4" />
-                <span>{success}</span>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* form */}
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="fullName" className="text-sm font-medium text-slate-800">
-                Nome completo
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <UserPlus className="h-4 w-4" />
-                </span>
-                <input
-                  id="fullName"
-                  name="fullName"
-                  value={fullName}
-                  onChange={(e) => setFullName(e.target.value)}
-                  placeholder="João Silva"
-                  autoComplete="name"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
+            {/* conteúdo do formulário */}
+            <div className="relative flex flex-col justify-center p-6 sm:p-8 lg:p-10">
+              <div className="mb-8 text-center lg:hidden">
+                <div className="mx-auto mb-3 inline-grid h-16 w-16 place-items-center rounded-2xl border border-slate-200/60 bg-white/70 shadow">
+                  <UserPlus className="h-8 w-8 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-slate-900">Criar conta</h2>
+                <p className="mt-2 text-sm text-slate-600">Cadastre um novo usuário para acessar a Evastur.</p>
               </div>
-            </motion.div>
 
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="email" className="text-sm font-medium text-slate-800">
-                E-mail
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <Mail className="h-4 w-4" />
-                </span>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="voce@empresa.com"
-                  autoComplete="email"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
+              <div className="mb-8 hidden text-left lg:block">
+                <div className="inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50/60 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                  <Sparkles className="h-4 w-4" />
+                  Novo por aqui?
+                </div>
+                <h2 className="mt-4 text-3xl font-bold text-slate-900">Cadastre seu acesso</h2>
+                <p className="mt-2 text-sm text-slate-600">Preencha os dados abaixo e aproveite todos os benefícios Evastur.</p>
               </div>
-            </motion.div>
 
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="username" className="text-sm font-medium text-slate-800">
-                Usuário
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <UserRound className="h-4 w-4" />
-                </span>
-                <input
-                  id="username"
-                  name="username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder="usuario.evastur"
-                  autoComplete="username"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
-              </div>
-            </motion.div>
-
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-2"
-            >
-              <div className="space-y-1.5">
-                <label htmlFor="password" className="text-sm font-medium text-slate-800">
-                  Senha
-                </label>
-                <div className="relative">
-                  <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                    <LockKeyhole className="h-4 w-4" />
-                  </span>
-                  <input
-                    id="password"
-                    name="password"
-                    type={showPass ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="Crie uma senha segura"
-                    autoComplete="new-password"
-                    required
-                    className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                  />
-                  <button
-                    type="button"
-                    aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
-                    onClick={() => setShowPass((v) => !v)}
-                    className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
+              {/* alertas */}
+              <AnimatePresence mode="wait">
+                {error && (
+                  <motion.div
+                    key="error"
+                    initial={fieldMotion.initial}
+                    animate={fieldMotion.animate}
+                    exit={fieldMotion.exit}
+                    transition={fieldTransition}
+                    className="mb-4 flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
                   >
-                    {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
-              <div className="space-y-1">
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
-                  <div
-                    className={`h-full ${strengthBarClass} transition-all`}
-                    style={{ width: `${(strength / 5) * 100}%` }}
-                  />
-                </div>
-                <div className="flex items-center gap-2 text-xs text-slate-600">
-                  <ShieldCheck className="h-3.5 w-3.5 text-blue-600" />
-                  <span>
-                    Força da senha: <strong>{strengthLabel}</strong>
-                  </span>
-                </div>
-              </div>
-            </motion.div>
+                    <AlertCircle className="h-4 w-4" />
+                    <span>{error}</span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+              <AnimatePresence mode="wait">
+                {success && (
+                  <motion.div
+                    key="success"
+                    initial={fieldMotion.initial}
+                    animate={fieldMotion.animate}
+                    exit={fieldMotion.exit}
+                    transition={fieldTransition}
+                    className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    <span>{success}</span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
 
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-1.5"
-            >
-              <label htmlFor="confirmPassword" className="text-sm font-medium text-slate-800">
-                Confirmar senha
-              </label>
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                  <LockKeyhole className="h-4 w-4" />
-                </span>
-                <input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type={showConfirmPass ? "text" : "password"}
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  placeholder="Repita a senha"
-                  autoComplete="new-password"
-                  required
-                  className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
-                />
-                <button
-                  type="button"
-                  aria-label={showConfirmPass ? "Ocultar confirmação" : "Mostrar confirmação"}
-                  onClick={() => setShowConfirmPass((v) => !v)}
-                  className="absolute inset-y-0 right-0 grid w-10 place-items-center text-slate-500 transition hover:text-slate-700"
-                >
-                  {showConfirmPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-            </motion.div>
-
-            <motion.div
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={fieldTransition}
-              className="space-y-2"
-            >
-              <p className="text-sm font-medium text-slate-800">Tipo de perfil</p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {profileOptions.map((option) => {
-                  const OptionIcon = option.icon;
-                  const isActive = profileType === option.value;
-                  return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      onClick={() => setProfileType(option.value)}
-                      aria-pressed={isActive}
-                      className={`group flex w-full flex-col items-start gap-2 rounded-2xl border px-4 py-3 text-left transition-all ${
-                        isActive
-                          ? "border-blue-400 bg-blue-50/80 text-blue-900 shadow-lg shadow-blue-500/20"
-                          : "border-slate-200 bg-white/70 text-slate-700 hover:border-blue-200 hover:bg-blue-50/40"
-                      }`}
-                    >
-                      <div
-                        className={`grid h-10 w-10 place-items-center rounded-xl transition-colors ${
-                          isActive ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-500"
-                        }`}
-                      >
-                        <OptionIcon className="h-5 w-5" />
-                      </div>
-                      <div className="space-y-1">
-                        <p className="text-sm font-semibold">{option.label}</p>
-                        <p className="text-xs text-slate-500">{option.description}</p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            </motion.div>
-
-            <AnimatePresence initial={false}>
-              {profileType === "admin" && (
+              {/* form */}
+              <form onSubmit={handleSubmit} className="space-y-5">
                 <motion.div
-                  key="admin-code"
                   initial={fieldMotion.initial}
                   animate={fieldMotion.animate}
-                  exit={fieldMotion.exit}
                   transition={fieldTransition}
                   className="space-y-1.5"
                 >
-                  <label htmlFor="adminCode" className="text-sm font-medium text-slate-800">
-                    Código de administrador
+                  <label htmlFor="fullName" className="text-sm font-medium text-slate-800">
+                    Nome completo
                   </label>
                   <div className="relative">
                     <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
-                      <ShieldCheck className="h-4 w-4" />
+                      <UserPlus className="h-4 w-4" />
                     </span>
                     <input
-                      id="adminCode"
-                      name="adminCode"
-                      type="password"
-                      value={adminCode}
-                      onChange={(e) => setAdminCode(e.target.value)}
-                      placeholder="Informe o código"
-                      autoComplete="one-time-code"
+                      id="fullName"
+                      name="fullName"
+                      value={fullName}
+                      onChange={(e) => setFullName(e.target.value)}
+                      placeholder="João Silva"
+                      autoComplete="name"
                       required
-                      className="w-full rounded-xl border border-slate-200 bg-white/90 py-2.5 pl-9 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_3px_rgba(59,130,246,0.15)]"
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
                     />
                   </div>
-                  <p className="text-xs text-slate-500">
-                    Apenas gestores autorizados podem criar contas administrativas.
-                  </p>
                 </motion.div>
-              )}
-            </AnimatePresence>
 
-            <motion.button
-              type="submit"
-              disabled={loading}
-              initial={fieldMotion.initial}
-              animate={fieldMotion.animate}
-              transition={{ ...fieldTransition, delay: 0.05 }}
-              whileHover={{ translateY: loading ? 0 : -2 }}
-              whileTap={{ scale: loading ? 1 : 0.98 }}
-              className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {loading ? (
-                <>
-                  <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
-                  Salvando...
-                </>
-              ) : (
-                <>
-                  Cadastrar
-                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-                </>
-              )}
-            </motion.button>
-          </form>
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
+                >
+                  <label htmlFor="email" className="text-sm font-medium text-slate-800">
+                    E-mail
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <Mail className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="email"
+                      name="email"
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="voce@empresa.com"
+                      autoComplete="email"
+                      required
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                    />
+                  </div>
+                </motion.div>
 
-          {/* rodapé do card */}
-          <p className="mt-5 text-center text-sm text-slate-600">
-            Já tem conta?{" "}
-            <Link href="/login" className="font-semibold text-blue-700 hover:underline">
-              Faça login
-            </Link>
-          </p>
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
+                >
+                  <label htmlFor="username" className="text-sm font-medium text-slate-800">
+                    Usuário
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <UserRound className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="username"
+                      name="username"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      placeholder="usuario.evastur"
+                      autoComplete="username"
+                      required
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                    />
+                  </div>
+                </motion.div>
+
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-2"
+                >
+                  <div className="space-y-1.5">
+                    <label htmlFor="password" className="text-sm font-medium text-slate-800">
+                      Senha
+                    </label>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                        <LockKeyhole className="h-4 w-4" />
+                      </span>
+                      <input
+                        id="password"
+                        name="password"
+                        type={showPass ? "text" : "password"}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="Crie uma senha segura"
+                        autoComplete="new-password"
+                        required
+                        className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                      />
+                      <button
+                        type="button"
+                        aria-label={showPass ? "Ocultar senha" : "Mostrar senha"}
+                        onClick={() => setShowPass((v) => !v)}
+                        className="absolute inset-y-0 right-0 grid w-12 place-items-center text-slate-500 transition hover:text-slate-700"
+                      >
+                        {showPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
+                      <div
+                        className={`h-full ${strengthBarClass} transition-all`}
+                        style={{ width: `${(strength / 5) * 100}%` }}
+                      />
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-slate-600">
+                      <ShieldCheck className="h-3.5 w-3.5 text-blue-600" />
+                      <span>
+                        Força da senha: <strong>{strengthLabel}</strong>
+                      </span>
+                    </div>
+                  </div>
+                </motion.div>
+
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-1.5"
+                >
+                  <label htmlFor="confirmPassword" className="text-sm font-medium text-slate-800">
+                    Confirmar senha
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                      <LockKeyhole className="h-4 w-4" />
+                    </span>
+                    <input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type={showConfirmPass ? "text" : "password"}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="Repita a senha"
+                      autoComplete="new-password"
+                      required
+                      className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-12 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                    />
+                    <button
+                      type="button"
+                      aria-label={showConfirmPass ? "Ocultar confirmação" : "Mostrar confirmação"}
+                      onClick={() => setShowConfirmPass((v) => !v)}
+                      className="absolute inset-y-0 right-0 grid w-12 place-items-center text-slate-500 transition hover:text-slate-700"
+                    >
+                      {showConfirmPass ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </motion.div>
+
+                <motion.div
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={fieldTransition}
+                  className="space-y-2"
+                >
+                  <p className="text-sm font-medium text-slate-800">Tipo de perfil</p>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {profileOptions.map((option) => {
+                      const OptionIcon = option.icon;
+                      const isActive = profileType === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => setProfileType(option.value)}
+                          aria-pressed={isActive}
+                          className={`group flex w-full flex-col items-start gap-2 rounded-2xl border px-4 py-3 text-left transition-all ${
+                            isActive
+                              ? "border-blue-400 bg-blue-50/80 text-blue-900 shadow-lg shadow-blue-500/20"
+                              : "border-slate-200 bg-white/70 text-slate-700 hover:border-blue-200 hover:bg-blue-50/40"
+                          }`}
+                        >
+                          <div
+                            className={`grid h-10 w-10 place-items-center rounded-xl transition-colors ${
+                              isActive ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-500"
+                            }`}
+                          >
+                            <OptionIcon className="h-5 w-5" />
+                          </div>
+                          <div className="space-y-1">
+                            <p className="text-sm font-semibold">{option.label}</p>
+                            <p className="text-xs text-slate-500">{option.description}</p>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </motion.div>
+
+                <AnimatePresence initial={false}>
+                  {profileType === "admin" && (
+                    <motion.div
+                      key="admin-code"
+                      initial={fieldMotion.initial}
+                      animate={fieldMotion.animate}
+                      exit={fieldMotion.exit}
+                      transition={fieldTransition}
+                      className="space-y-1.5"
+                    >
+                      <label htmlFor="adminCode" className="text-sm font-medium text-slate-800">
+                        Código de administrador
+                      </label>
+                      <div className="relative">
+                        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                          <ShieldCheck className="h-4 w-4" />
+                        </span>
+                        <input
+                          id="adminCode"
+                          name="adminCode"
+                          type="password"
+                          value={adminCode}
+                          onChange={(e) => setAdminCode(e.target.value)}
+                          placeholder="Informe o código"
+                          autoComplete="one-time-code"
+                          required
+                          className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-10 pr-3.5 text-sm text-slate-900 outline-none transition focus:border-blue-400 focus:shadow-[0_0_0_4px_rgba(59,130,246,0.12)]"
+                        />
+                      </div>
+                      <p className="text-xs text-slate-500">
+                        Apenas gestores autorizados podem criar contas administrativas.
+                      </p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                <motion.button
+                  type="submit"
+                  disabled={loading}
+                  initial={fieldMotion.initial}
+                  animate={fieldMotion.animate}
+                  transition={{ ...fieldTransition, delay: 0.05 }}
+                  whileHover={{ translateY: loading ? 0 : -2 }}
+                  whileTap={{ scale: loading ? 1 : 0.98 }}
+                  className="group inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-cyan-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {loading ? (
+                    <>
+                      <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                      Salvando...
+                    </>
+                  ) : (
+                    <>
+                      Cadastrar
+                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                    </>
+                  )}
+                </motion.button>
+              </form>
+
+              {/* rodapé do card */}
+              <p className="mt-6 text-center text-sm text-slate-600">
+                Já tem conta?{" "}
+                <Link href="/login" className="font-semibold text-blue-700 transition hover:text-blue-800">
+                  Faça login
+                </Link>
+              </p>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -12,7 +12,6 @@ import {
   LogOut,
   MapPin,
   User,
-  Sparkles,
   Crown,
   Menu,
   X,


### PR DESCRIPTION
## Summary
- restyle the login screen with a wider glassmorphism card and inspirational desktop panel to balance desktop and mobile experiences
- refresh the signup screen with a matching responsive two-column layout and refined form spacing for clarity
- remove unused icon imports flagged by lint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e31819a8c483339b6757a860c4c19e