### PR TITLE
Handle undefined background image responses in gallery manager

### DIFF
--- a/components/BackgroundGalleryManager.tsx
+++ b/components/BackgroundGalleryManager.tsx
@@ -381,11 +381,13 @@ export function BackgroundGalleryManager() {
         error?: string;
       };
 
-      if (!response.ok || !data.image) {
+      const newImage = data.image;
+
+      if (!response.ok || !newImage) {
         throw new Error(data.error ?? "Não foi possível adicionar a imagem");
       }
 
-      setBackgrounds((current) => [toBackgroundWithDraft(data.image), ...current]);
+      setBackgrounds((current) => [toBackgroundWithDraft(newImage), ...current]);
       setNewBackgroundUrl("");
       setNewBackgroundTitle("");
       setNewBackgroundGroup("");


### PR DESCRIPTION
## Summary
- ensure the gallery manager narrows the optional image returned from the API
- reuse the narrowed value when updating local background state

## Testing
- `npm run vercel-build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e328929230833388505a11c67cccb0