### PR TITLE
Handle missing DATABASE_URL in Vercel build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "vercel-build": "prisma generate && prisma migrate deploy && next build",
+    "vercel-build": "node scripts/vercel-build.js",
     "start": "next start",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev --name init",

--- a/scripts/vercel-build.js
+++ b/scripts/vercel-build.js
@@ -1,0 +1,32 @@
+const { execSync } = require('node:child_process');
+
+function run(command) {
+  execSync(command, { stdio: 'inherit', env: process.env });
+}
+
+const hasDatabaseUrl = typeof process.env.DATABASE_URL === 'string' && process.env.DATABASE_URL.trim().length > 0;
+
+try {
+  run('prisma generate');
+} catch (error) {
+  console.error('Failed to run "prisma generate".', error);
+  process.exit(error.status ?? 1);
+}
+
+if (hasDatabaseUrl) {
+  try {
+    run('prisma migrate deploy');
+  } catch (error) {
+    console.error('Failed to run "prisma migrate deploy".', error);
+    process.exit(error.status ?? 1);
+  }
+} else {
+  console.warn('Skipping "prisma migrate deploy" because DATABASE_URL is not defined.');
+}
+
+try {
+  run('next build');
+} catch (error) {
+  console.error('Failed to run "next build".', error);
+  process.exit(error.status ?? 1);
+}


### PR DESCRIPTION
## Summary
- replace the vercel-build npm script with a Node helper that wraps the build steps
- keep Prisma client generation while skipping migrations when DATABASE_URL is not provided
- allow the Next.js build to succeed even without database credentials in Vercel

## Testing
- npm run vercel-build

------
https://chatgpt.com/codex/tasks/task_e_68e32a0d86d883338dc2204b4b58fae4