### PR TITLE
Fix login redirect for authenticated users

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { AuthProvider } from "@/components/auth-provider";
 import { Navbar } from "@/components/navbar";
 import { Toaster } from "@/components/ui/sonner";
 import { auth } from "@/lib/auth";
@@ -36,9 +37,11 @@ export default async function RootLayout({
   return (
     <html lang="pt-BR">
       <body className="font-sans antialiased">
-        <Navbar user={session?.user ?? null} favoriteCount={favoriteCount} />
-        <div className="pt-20 lg:pt-24">{children}</div>
-        <Toaster richColors closeButton position="top-right" />
+        <AuthProvider session={session}>
+          <Navbar user={session?.user ?? null} favoriteCount={favoriteCount} />
+          <div className="pt-20 lg:pt-24">{children}</div>
+          <Toaster richColors closeButton position="top-right" />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Plane,
@@ -48,6 +49,7 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+  const { data: session, status } = useSession();
 
   // Estado do form (inalterado)
   const [username, setUsername] = useState("");
@@ -107,28 +109,6 @@ export default function LoginPage() {
       }
 
       setSuccess("Login realizado com sucesso! Redirecionando...");
-
-      try {
-        const response = await fetch("/api/auth/session");
-        if (response.ok) {
-          const session = await response.json();
-          const role = session?.user?.role === "admin" ? "admin" : "user";
-          const destination =
-            callbackUrl && callbackUrl !== "/"
-              ? callbackUrl
-              : role === "admin"
-                ? "/dashboard"
-                : "/usuario";
-
-          router.push(destination);
-          router.refresh();
-          return;
-        }
-      } catch (sessionError) {
-        console.error("Falha ao recuperar sessão após login", sessionError);
-      }
-
-      router.push(callbackUrl);
       router.refresh();
     } catch (authError) {
       console.error("Falha ao fazer login", authError);
@@ -137,6 +117,22 @@ export default function LoginPage() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (status !== "authenticated" || !session?.user) {
+      return;
+    }
+
+    const role = session.user.role === "admin" ? "admin" : "user";
+    const destination =
+      callbackUrl && callbackUrl !== "/"
+        ? callbackUrl
+        : role === "admin"
+          ? "/dashboard"
+          : "/usuario";
+
+    router.replace(destination);
+  }, [session, status, callbackUrl, router]);
 
   return (
     <main className="relative min-h-dvh overflow-hidden bg-gradient-to-br from-blue-50 via-white to-cyan-50">


### PR DESCRIPTION
## Summary
- wrap the root layout with the NextAuth provider so client components react to session updates
- update the login page to rely on the session state and redirect authenticated users away from the login form

## Testing
- npm run lint *(fails: scripts/vercel-build.js 1:22  error  A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e32c199a3083338deb6d4c152fa18f