### PR TITLE
Ensure NextAuth secret is shared with middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Aplicação base construída com Next.js 15 e autenticação via [NextAuth.js](h
 - A tela de login fica em [`app/login/page.tsx`](app/login/page.tsx) e envia formulários diretamente para os endpoints padrão do NextAuth.
 - Após autenticação bem-sucedida, o usuário é redirecionado para `/dashboard?login=success`, onde um toast confirma o sucesso do login.
 
+## Variáveis de ambiente obrigatórias
+- Defina `AUTH_SECRET` (ou `NEXTAUTH_SECRET`) com um valor aleatório e seguro, por exemplo `openssl rand -base64 32`. Esse segredo é compartilhado entre o NextAuth e a [middleware de proteção de rotas](middleware.ts) por meio de [`lib/auth-secret.ts`](lib/auth-secret.ts). Sem ele, rotas privadas retornarão para a tela de login com erros de validação de token.
+
 ## Debug do login com Google OAuth
 1. **Verifique variáveis de ambiente obrigatórias**
    - `AUTH_GOOGLE_ID` e `AUTH_GOOGLE_SECRET` devem existir e corresponder às credenciais geradas no [Google Cloud Console](https://console.cloud.google.com/).

--- a/lib/auth-secret.ts
+++ b/lib/auth-secret.ts
@@ -1,0 +1,9 @@
+const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? undefined;
+
+if (!secret && process.env.NODE_ENV === "production") {
+  console.error(
+    "AUTH_SECRET ou NEXTAUTH_SECRET não está definido. Rotas protegidas não funcionarão sem um segredo compartilhado.",
+  );
+}
+
+export const authSecret = secret;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import { CredentialsSignin } from "next-auth";
 // import Google from "next-auth/providers/google";
 import { z } from "zod";
 
+import { authSecret } from "./auth-secret";
 import { prisma } from "./prisma";
 import { verifyPassword } from "./hash";
 
@@ -18,6 +19,7 @@ export const {
   signIn,
   signOut,
 } = NextAuth({
+  secret: authSecret,
   session: { strategy: "jwt" },
   providers: [
     Credentials({

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
+import { authSecret } from "./lib/auth-secret";
+
 const protectedMatchers = [
   "/dashboard",
   "/api/profile",
@@ -14,8 +16,14 @@ const protectedMatchers = [
 
 async function isAuthenticated(request: NextRequest) {
   try {
-    const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
-    const token = await getToken({ req: request, secret });
+    if (!authSecret) {
+      console.error(
+        "AUTH_SECRET ou NEXTAUTH_SECRET não está definido. Configure a variável para proteger as rotas privadas.",
+      );
+      return false;
+    }
+
+    const token = await getToken({ req: request, secret: authSecret });
     return Boolean(token?.userId ?? token?.sub);
   } catch (error) {
     console.error("Erro ao validar token na middleware", error);


### PR DESCRIPTION
## Summary
- share a single auth secret helper between NextAuth and the middleware to avoid token validation failures
- add defensive logging when the secret is missing to surface configuration issues
- document the required AUTH_SECRET/NEXTAUTH_SECRET environment variable in the README

## Testing
- npm run lint (fails: scripts/vercel-build.js violates no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68e32df001a88333ac059e5209a2120c