### PR TITLE
Handle Prisma migrate deploy with direct database URL

### DIFF
--- a/scripts/vercel-build.js
+++ b/scripts/vercel-build.js
@@ -1,7 +1,14 @@
 const { execSync } = require('node:child_process');
 
-function run(command) {
-  execSync(command, { stdio: 'inherit', env: process.env });
+function run(command, options = {}) {
+  const { env, ...execOptions } = options;
+  const mergedEnv = env ? { ...process.env, ...env } : process.env;
+
+  execSync(command, {
+    stdio: 'inherit',
+    ...execOptions,
+    env: mergedEnv,
+  });
 }
 
 const hasDatabaseUrl = typeof process.env.DATABASE_URL === 'string' && process.env.DATABASE_URL.trim().length > 0;
@@ -14,8 +21,21 @@ try {
 }
 
 if (hasDatabaseUrl) {
+  const directDatabaseUrl = [
+    process.env.DIRECT_DATABASE_URL,
+    process.env.DIRECT_URL,
+    process.env.SHADOW_DATABASE_URL,
+  ].find((value) => typeof value === 'string' && value.trim().length > 0);
+
+  const migrateEnvOverrides = {};
+
+  if (directDatabaseUrl) {
+    migrateEnvOverrides.DATABASE_URL = directDatabaseUrl;
+    console.log('Using direct database connection string for migrations.');
+  }
+
   try {
-    run('prisma migrate deploy');
+    run('prisma migrate deploy', { env: migrateEnvOverrides });
   } catch (error) {
     console.error('Failed to run "prisma migrate deploy".', error);
     process.exit(error.status ?? 1);


### PR DESCRIPTION
## Summary
- allow the Vercel build script to merge custom environment variables when running commands
- use a direct database connection string for `prisma migrate deploy` when available so deployments succeed with Accelerate/Data Proxy setups

## Testing
- CI=1 npm run vercel-build

------
https://chatgpt.com/codex/tasks/task_e_68e33545d7748333823b560404ef4f91