### PR TITLE
Fix login redirect to navigate after successful sign-in

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -109,6 +109,37 @@ export default function LoginPage() {
       }
 
       setSuccess("Login realizado com sucesso! Redirecionando...");
+
+      const normalizeAppUrl = (url: string | null | undefined) => {
+        if (!url) {
+          return null;
+        }
+
+        if (url.startsWith("/")) {
+          return url;
+        }
+
+        try {
+          const parsed = new URL(url);
+          if (typeof window !== "undefined" && parsed.origin === window.location.origin) {
+            return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+          }
+        } catch (error) {
+          console.warn("Não foi possível normalizar a URL de redirecionamento.", error);
+        }
+
+        return null;
+      };
+
+      const normalizedResultUrl = normalizeAppUrl(result.url);
+      const normalizedCallbackUrl = normalizeAppUrl(callbackUrl);
+      const destination =
+        normalizedResultUrl ??
+        normalizedCallbackUrl ??
+        (callbackUrl && callbackUrl !== "/" ? callbackUrl : null) ??
+        "/";
+
+      router.replace(destination);
       router.refresh();
     } catch (authError) {
       console.error("Falha ao fazer login", authError);

--- a/scripts/vercel-build.js
+++ b/scripts/vercel-build.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { execSync } = require('node:child_process');
 
 function run(command, options = {}) {


### PR DESCRIPTION
## Summary
- normalize the callback URL returned by NextAuth and immediately replace the route after a successful login attempt
- refresh the router after navigation so the session-aware layout updates without waiting for the effect redirect
- silence the lint error for the CommonJS vercel build helper to keep eslint passing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3372504248333b969ab22ce038bf4