### PR TITLE
Allow signing in with username or email

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -287,7 +287,7 @@ export default function LoginPage() {
                   className="space-y-1.5"
                 >
                   <label htmlFor="username" className="text-sm font-medium text-slate-800">
-                    Usuário
+                    Usuário ou e-mail
                   </label>
                   <div className="relative">
                     <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { CredentialsSignin } from "next-auth";
+import { Prisma } from "@prisma/client";
 // import Google from "next-auth/providers/google";
 import { z } from "zod";
 
@@ -34,11 +35,37 @@ export const {
           return null;
         }
 
-        const { username, password } = parsed.data;
+        const { username: identifier, password } = parsed.data;
+
+        const normalizedIdentifier = identifier.trim();
+        const possibleEmail = normalizedIdentifier.includes("@");
+        const identifierFilter: Prisma.UserWhereInput = possibleEmail
+          ? {
+              OR: [
+                {
+                  username: {
+                    equals: normalizedIdentifier,
+                    mode: "insensitive",
+                  },
+                },
+                {
+                  email: {
+                    equals: normalizedIdentifier.toLowerCase(),
+                    mode: "insensitive",
+                  },
+                },
+              ],
+            }
+          : {
+              username: {
+                equals: normalizedIdentifier,
+                mode: "insensitive",
+              },
+            };
 
         let user = null;
         try {
-          user = await prisma.user.findUnique({ where: { username } });
+          user = await prisma.user.findFirst({ where: identifierFilter });
         } catch (dbError) {
           console.error("Erro ao consultar usuário no banco de dados", dbError);
           const error = new CredentialsSignin("Não foi possível validar suas credenciais no momento.");


### PR DESCRIPTION
## Summary
- update credential authorization to locate users by username or email with case-insensitive matching
- refresh the login form label to reflect email-based sign-in support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e338afedd48333a587dd955d830e89