### PR TITLE
Reduce middleware bundle size

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -165,4 +165,7 @@ export const {
       return session;
     },
   },
+  pages: {
+    signIn: "/login",
+  },
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,33 +1,12 @@
-import { NextResponse } from "next/server";
-import { auth } from "./lib/auth";
+import { withAuth } from "next-auth/middleware";
 
-const protectedMatchers = [
-  "/dashboard",
-  "/api/profile",
-  "/usuario",
-  "/favoritos",
-  "/api/favorites",
-];
-export default auth(async (request) => {
-  const { pathname } = request.nextUrl;
-  const requiresAuth = protectedMatchers.some(
-    (path) => pathname === path || pathname.startsWith(`${path}/`),
-  );
-
-  if (!requiresAuth) {
-    return NextResponse.next();
-  }
-
-  if (request.auth) {
-    return NextResponse.next();
-  }
-
-  const redirectUrl = new URL("/login", request.url);
-  redirectUrl.searchParams.set(
-    "callbackUrl",
-    request.nextUrl.pathname + request.nextUrl.search,
-  );
-  return NextResponse.redirect(redirectUrl);
+export default withAuth({
+  callbacks: {
+    authorized: ({ token }) => !!token,
+  },
+  pages: {
+    signIn: "/login",
+  },
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
- replace the middleware implementation with next-auth's lightweight withAuth helper to avoid bundling Prisma on the edge
- configure NextAuth to use the custom /login page for sign-in redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33ba051408333874d5932943406d2