### PR TITLE
Improve home page responsiveness and animation polish

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,21 @@
   50% { transform: translateY(-8px) scale(1.1); }
 }
 
+@keyframes float-slow {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(0, -12px, 0) scale(1.05); }
+}
+
+@keyframes float-slower {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(-8px, 10px, 0) scale(1.08); }
+}
+
+@keyframes fade-up {
+  0% { opacity: 0; transform: translateY(20px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 @keyframes shine {
   0% { transform: translateX(-100%) skewX(-12deg); }
   100% { transform: translateX(200%) skewX(-12deg); }
@@ -142,6 +157,18 @@
 
 .animate-float-delayed {
   animation: float-delayed 8s ease-in-out infinite;
+}
+
+.animate-float-slow {
+  animation: float-slow 10s ease-in-out infinite;
+}
+
+.animate-float-slower {
+  animation: float-slower 14s ease-in-out infinite;
+}
+
+.animate-fade-up {
+  animation: fade-up 0.9s ease-out forwards;
 }
 
 .animate-shine {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,67 +155,68 @@ export default async function HomePage() {
       {/* Seção de destinos com estética alinhada à página /destinos */}
       <section
         id="destinos"
-        className="relative mx-auto -mt-12 w-full max-w-7xl px-4 pb-16 pt-5 sm:px-6 sm:pt-9 md:-mt-14 lg:px-8"
+        className="relative mx-auto -mt-10 w-full max-w-6xl px-4 pb-16 pt-6 sm:px-6 md:-mt-12 md:pt-10 lg:max-w-7xl lg:px-8"
       >
-        <div className="group relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-white/70 to-white/50 p-5 shadow-2xl shadow-black/5 backdrop-blur-xl transition-all duration-500 hover:shadow-3xl dark:from-white/[0.06] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
-          {/* Glow suave no hover */}
+        <div className="pointer-events-none absolute inset-x-6 -top-10 -z-10 hidden h-[420px] rounded-[2.5rem] bg-gradient-to-br from-blue-400/15 via-transparent to-purple-400/15 blur-3xl sm:block" />
+
+        <div className="group relative overflow-hidden rounded-[2.25rem] border border-white/15 bg-gradient-to-br from-white/80 via-white/65 to-white/55 p-5 shadow-2xl shadow-black/5 backdrop-blur-xl transition-all duration-500 hover:shadow-3xl dark:from-white/[0.07] dark:via-white/[0.05] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
           <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-purple-500/5" />
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-purple-500/10" />
           </div>
 
+          <div className="pointer-events-none absolute -left-20 top-12 size-44 rounded-full bg-blue-500/10 blur-3xl sm:-left-12 sm:top-10 sm:size-60" />
+          <div className="pointer-events-none absolute -right-16 bottom-12 size-48 rounded-full bg-purple-500/15 blur-3xl sm:-right-12 sm:bottom-16 sm:size-60" />
+
           <div className="relative">
-            {/* Header da seção */}
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between md:gap-6">
-              <div className="flex-1">
-                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-gradient-to-r from-primary/15 to-primary/10 px-3.5 py-1.5 text-xs font-semibold text-primary shadow-sm backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:shadow-md sm:text-sm">
-                  <Sparkles className="size-3.5 animate-pulse sm:size-4" />
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between md:gap-6">
+              <div className="flex-1 space-y-3">
+                <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-gradient-to-r from-primary/15 via-primary/10 to-primary/5 px-3 py-1 text-[0.7rem] font-semibold text-primary shadow-sm shadow-primary/10 backdrop-blur-sm transition-all duration-300 hover:scale-[1.03] hover:shadow-md sm:px-3.5 sm:py-1.5 sm:text-xs">
+                  <Sparkles className="size-3 animate-pulse sm:size-3.5" />
                   <span>Seleção Evastur</span>
-                  <Star className="size-3 fill-primary text-primary sm:size-3.5" />
+                  <Star className="size-3 fill-primary text-primary" />
                 </div>
 
-                <h2 className="text-balance text-2xl font-bold tracking-tight text-foreground sm:text-3xl md:text-4xl lg:text-5xl">
+                <h2 className="text-balance text-[clamp(1.7rem,4vw,2.6rem)] font-semibold tracking-tight text-foreground sm:font-bold">
                   Destinos que contam
                   <span className="ml-2 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-purple-400">
                     histórias
                   </span>
                 </h2>
 
-                <p className="mt-2.5 max-w-prose text-sm leading-relaxed text-muted-foreground sm:text-base md:mt-3 md:leading-relaxed lg:text-lg">
-                  Curadoria fina, charme local e experiências que você só descobre
-                  com quem entende do assunto.
+                <p className="max-w-prose text-pretty text-[0.9rem] leading-relaxed text-muted-foreground sm:text-[0.95rem] md:text-base">
+                  Curadoria fina, charme local e experiências que você só descobre com quem entende do assunto.
                 </p>
               </div>
 
               <Link
                 href="/destinos"
-                className="group/btn relative inline-flex items-center gap-2.5 self-start overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-white/20 to-white/10 px-5 py-2.5 text-sm font-semibold backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:from-primary/20 hover:to-primary/10 hover:shadow-lg hover:shadow-primary/25 sm:px-6 sm:py-3 sm:text-base"
+                className="group/btn relative inline-flex items-center gap-2 self-start overflow-hidden rounded-full border border-primary/10 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent px-4 py-2 text-[0.85rem] font-semibold text-primary backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:from-primary/20 hover:via-primary/10 hover:to-primary/5 hover:text-primary sm:px-5 sm:py-2.5 sm:text-sm"
                 aria-label="Ver todos os destinos"
               >
-                <span className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent opacity-0 transition-opacity duration-300 group-hover/btn:opacity-100" />
-                <MapPin className="size-4 transition-all duration-300 group-hover/btn:-translate-y-0.5 group-hover/btn:text-primary sm:size-5" />
+                <span className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/25 to-transparent opacity-0 transition-opacity duration-300 group-hover/btn:opacity-100" />
+                <MapPin className="size-4 transition-all duration-300 group-hover/btn:-translate-y-0.5 group-hover/btn:text-primary" />
                 <span>Ver todos</span>
-                <ArrowRight className="size-4 transition-all duration-300 group-hover/btn:translate-x-1 sm:size-5" />
+                <ArrowRight className="size-4 transition-all duration-300 group-hover/btn:translate-x-1" />
               </Link>
             </div>
 
-            {/* Grid de destinos (sem mudar a API/props) */}
-            <div className="mt-6 sm:mt-8 md:mt-10">
-              <DestinationGrid
-                destinations={destinations}
-                canFavorite={Boolean(session?.user?.id)}
-              />
+            <div className="mt-6 sm:mt-8 md:mt-9">
+              <div className="motion-safe:animate-[fade-up_0.9s_ease-out_forwards] motion-safe:opacity-0">
+                <DestinationGrid
+                  destinations={destinations}
+                  canFavorite={Boolean(session?.user?.id)}
+                />
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Features/benefícios com visual coeso (só UI) */}
-      <section className="mx-auto w-full max-w-7xl px-4 pb-16 sm:px-6 sm:pb-20 lg:px-8 lg:pb-24">
-        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-white/70 to-white/50 p-5 backdrop-blur-xl dark:from-white/[0.06] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
-          {/* Decoração de fundo */}
+      <section className="mx-auto w-full max-w-6xl px-4 pb-16 sm:px-6 sm:pb-20 lg:max-w-7xl lg:px-8 lg:pb-24">
+        <div className="relative overflow-hidden rounded-[2.25rem] border border-white/15 bg-gradient-to-br from-white/80 via-white/65 to-white/55 p-5 backdrop-blur-xl dark:from-white/[0.07] dark:via-white/[0.05] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
           <div className="pointer-events-none absolute inset-0 opacity-30">
-            <div className="absolute right-0 top-0 size-64 rounded-full bg-blue-500/10 blur-3xl" />
-            <div className="absolute bottom-0 left-0 size-64 rounded-full bg-purple-500/10 blur-3xl" />
+            <div className="absolute -top-20 left-14 size-60 rounded-full bg-blue-500/10 blur-3xl" />
+            <div className="absolute bottom-0 right-0 size-64 rounded-full bg-purple-500/10 blur-3xl" />
           </div>
 
           <div className="relative grid gap-4 sm:gap-5 md:grid-cols-3 md:gap-6">
@@ -241,26 +242,26 @@ export default async function HomePage() {
             ].map(({ title, desc, Icon, color }, i) => (
               <div
                 key={i}
-                className="group/card relative overflow-hidden rounded-2xl border border-white/15 bg-gradient-to-br from-white/60 to-white/40 p-5 backdrop-blur-sm transition-all duration-500 hover:-translate-y-2 hover:border-white/30 hover:shadow-2xl dark:from-white/[0.05] dark:to-white/[0.02] sm:p-6"
+                className="group/card relative overflow-hidden rounded-2xl border border-white/15 bg-gradient-to-br from-white/70 to-white/45 p-5 backdrop-blur-sm transition-all duration-500 hover:-translate-y-2 hover:border-white/40 hover:shadow-2xl dark:from-white/[0.05] dark:to-white/[0.02] sm:p-6"
+                style={{ animationDelay: `${i * 0.15}s` }}
               >
-                {/* Glow no hover (herda cores do item) */}
                 <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover/card:opacity-100">
                   <div className={`absolute inset-0 bg-gradient-to-br ${color}`} />
                 </div>
 
                 <div className="relative flex flex-col gap-4 sm:flex-row sm:items-start">
-                  <div className={`relative grid size-14 shrink-0 place-items-center overflow-hidden rounded-2xl border border-white/20 bg-gradient-to-br shadow-lg transition-all duration-500 group-hover/card:scale-110 group-hover/card:shadow-xl sm:size-16 ${color}`}>
+                  <div className={`relative grid size-14 shrink-0 place-items-center overflow-hidden rounded-2xl border border-white/20 bg-gradient-to-br shadow-lg transition-all duration-500 motion-safe:animate-[fade-up_0.9s_ease-out_forwards] motion-safe:opacity-0 group-hover/card:scale-110 group-hover/card:shadow-xl sm:size-16 ${color}`}>
                     <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/20 to-transparent" />
-                    <Icon className="relative z-10 size-7 transition-transform duration-500 group-hover/card:rotate-12 sm:size-8" />
+                    <Icon className="relative z-10 size-6 transition-transform duration-500 group-hover/card:rotate-12 sm:size-7" />
                   </div>
 
                   <div className="flex-1">
-                    <h3 className="text-base font-bold leading-tight sm:text-lg">{title}</h3>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">{desc}</p>
+                    <h3 className="text-[0.95rem] font-semibold leading-tight text-foreground sm:text-base">{title}</h3>
+                    <p className="mt-2 text-[0.85rem] leading-relaxed text-muted-foreground sm:text-[0.95rem]">{desc}</p>
                   </div>
                 </div>
 
-                <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-white/30 to-transparent opacity-0 transition-opacity duration-500 group-hover/card:opacity-100" />
+                <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-white/35 to-transparent opacity-0 transition-opacity duration-500 group-hover/card:opacity-100" />
               </div>
             ))}
           </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -102,7 +102,7 @@ export default function Hero({ images, userName }: HeroProps) {
   return (
     <section
       ref={containerRef}
-      className="relative isolate min-h-[86dvh] overflow-clip rounded-b-[2.5rem] border-b border-white/10 bg-black/60 sm:min-h-[88dvh] md:rounded-b-[3rem]"
+      className="relative isolate min-h-[78dvh] overflow-clip rounded-b-[2.25rem] border-b border-white/10 bg-black/70 sm:min-h-[82dvh] md:min-h-[86dvh] md:rounded-b-[3rem]"
       aria-label="Destaques Evastur"
       tabIndex={0}
       onMouseEnter={() => setPaused(true)}
@@ -116,7 +116,7 @@ export default function Hero({ images, userName }: HeroProps) {
           <div
             key={`${src}-${idx}`}
             className={cn(
-              "absolute inset-0 transition-all duration-[1800ms] ease-in-out will-change-transform",
+              "absolute inset-0 transition-all duration-[2000ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform",
               active === idx ? "scale-100 opacity-100" : "scale-105 opacity-0",
             )}
             aria-hidden={active !== idx}
@@ -142,30 +142,28 @@ export default function Hero({ images, userName }: HeroProps) {
       </div>
 
       {/* Partículas/blur blobs sutis (respeitam reduced-motion implicitamente) */}
-      <div className="pointer-events-none absolute inset-0 -z-10 opacity-40">
-        <div className="absolute left-1/3 top-1/4 size-72 animate-pulse rounded-full bg-blue-500/20 blur-3xl" />
-        <div
-          className="absolute bottom-1/4 right-1/3 size-64 animate-pulse rounded-full bg-purple-500/15 blur-3xl"
-          style={{ animationDelay: "1s" }}
-        />
+      <div className="pointer-events-none absolute inset-0 -z-10 opacity-45">
+        <div className="absolute left-[12%] top-[18%] size-72 animate-float-slow rounded-full bg-blue-500/25 blur-3xl" />
+        <div className="absolute bottom-[12%] right-[10%] size-64 animate-float-delayed rounded-full bg-purple-500/20 blur-3xl" />
+        <div className="absolute left-[48%] top-[58%] size-40 animate-float-slower rounded-full bg-emerald-400/15 blur-3xl" />
       </div>
 
-    
+
 
       {/* Conteúdo principal */}
-      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 md:py-24 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_520px] lg:items-start xl:grid-cols-[minmax(0,1fr)_600px] 2xl:grid-cols-[minmax(0,1fr)_640px]">
+      <div className="mx-auto w-full max-w-6xl px-4 py-14 sm:px-6 sm:py-[4.5rem] md:max-w-7xl md:py-20 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_500px] lg:items-start xl:grid-cols-[minmax(0,1fr)_560px] 2xl:grid-cols-[minmax(0,1fr)_600px]">
           <div className="flex flex-col gap-6 sm:gap-8 lg:pr-8 xl:pr-12">
             {/* Badge */}
-            <div className="group inline-flex w-fit animate-[fadeIn_1s_ease-out] items-center gap-2.5 rounded-full border border-white/25 bg-white/15 px-4 py-2 text-xs font-medium text-white shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:border-white/40 hover:bg-white/20 sm:text-sm">
+            <div className="group inline-flex w-fit animate-[fadeIn_1s_ease-out] items-center gap-2.5 rounded-full border border-white/25 bg-white/15 px-3.5 py-1.5 text-[0.75rem] font-medium text-white shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:border-white/40 hover:bg-white/20 sm:px-4 sm:py-2 sm:text-sm">
               <Sparkles className="size-3.5 animate-pulse text-yellow-300 sm:size-4" />
               <span>Agência boutique • experiências sob medida</span>
               <span className="size-1.5 animate-pulse rounded-full bg-green-400 shadow-[0_0_8px_theme(colors.green.400)]" />
             </div>
 
             {/* Headline */}
-            <div className="max-w-3xl animate-[fadeIn_1.2s_ease-out] space-y-5">
-              <h1 className="text-balance text-3xl font-bold leading-tight tracking-tight text-white drop-shadow-2xl sm:text-4xl md:text-5xl lg:text-6xl">
+            <div className="max-w-3xl animate-[fadeIn_1.2s_ease-out] space-y-4">
+              <h1 className="text-balance text-[clamp(2rem,5vw,3.25rem)] font-semibold leading-[1.1] tracking-tight text-white drop-shadow-2xl sm:font-bold md:text-[clamp(2.4rem,4vw,3.6rem)]">
                 Descubra o mundo com a{" "}
                 <span className="relative inline-block">
                   <span className="relative z-10 bg-gradient-to-r from-blue-400 via-blue-300 to-purple-400 bg-clip-text text-transparent">
@@ -179,7 +177,7 @@ export default function Hero({ images, userName }: HeroProps) {
                 : viagens premium, memórias eternas.
               </h1>
 
-              <p className="max-w-xl text-pretty text-sm leading-relaxed text-white/90 drop-shadow-lg sm:text-base md:text-lg md:leading-relaxed">
+              <p className="max-w-xl text-pretty text-[0.95rem] leading-relaxed text-white/85 drop-shadow-lg sm:text-[1.05rem] md:text-[1.15rem] md:leading-relaxed">
                 {userName ? (
                   <>
                     <span className="font-semibold text-white">{userName.split(" ")[0]}</span>, planejamos sua próxima jornada com
@@ -196,8 +194,8 @@ export default function Hero({ images, userName }: HeroProps) {
               <Link
                 href="/destinos"
                 className={cn(
-                  "group relative inline-flex items-center justify-center gap-2.5 overflow-hidden rounded-full border border-white/30 bg-gradient-to-r from-blue-500/90 to-purple-500/90 px-6 py-3.5 text-sm font-semibold text-white shadow-xl backdrop-blur transition-all duration-300",
-                  "hover:-translate-y-1 hover:shadow-2xl hover:shadow-blue-500/50 sm:px-7 sm:py-3.5 sm:text-base",
+                  "group relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-full border border-white/30 bg-gradient-to-r from-blue-500/90 to-purple-500/90 px-5 py-3 text-sm font-semibold text-white shadow-xl backdrop-blur transition-all duration-300",
+                  "hover:-translate-y-1 hover:shadow-2xl hover:shadow-blue-500/50 sm:px-6 sm:py-3 sm:text-[0.95rem]",
                 )}
               >
                 <span className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
@@ -208,7 +206,7 @@ export default function Hero({ images, userName }: HeroProps) {
 
               <Link
                 href="/sobre-nos"
-                className="group inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-5 py-3 text-sm font-medium text-white/95 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-white/40 hover:bg-white/20 hover:shadow-lg sm:px-6 sm:text-base"
+                className="group inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2.5 text-[0.85rem] font-medium text-white/95 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-white/40 hover:bg-white/20 hover:shadow-lg sm:px-5 sm:py-3 sm:text-[0.95rem]"
               >
                 <Compass className="size-4 transition-transform duration-300 group-hover:rotate-12 sm:size-5" />
                 <span>Conheça a Evastur</span>
@@ -216,7 +214,7 @@ export default function Hero({ images, userName }: HeroProps) {
 
               <Link
                 href="/contato"
-                className="group inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/40 bg-gradient-to-r from-emerald-500/20 to-emerald-400/20 px-5 py-3 text-sm font-medium text-emerald-50 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-emerald-400/60 hover:from-emerald-500/30 hover:to-emerald-400/30 hover:shadow-lg hover:shadow-emerald-500/30 sm:px-6 sm:text-base"
+                className="group inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/40 bg-gradient-to-r from-emerald-500/20 to-emerald-400/20 px-4 py-2.5 text-[0.85rem] font-medium text-emerald-50 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-emerald-400/60 hover:from-emerald-500/30 hover:to-emerald-400/30 hover:shadow-lg hover:shadow-emerald-500/30 sm:px-5 sm:py-3 sm:text-[0.95rem]"
               >
                 <CalendarCheck2 className="size-4 transition-transform duration-300 group-hover:scale-110 sm:size-5" />
                 <span>Montar roteiro</span>
@@ -228,12 +226,12 @@ export default function Hero({ images, userName }: HeroProps) {
               {featureHighlights.map(({ icon: Icon, label }) => (
                 <div
                   key={label}
-                  className="group flex items-center gap-3 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-white/30 hover:bg-white/15"
+                  className="group flex items-center gap-3 rounded-2xl border border-white/15 bg-white/10 px-3.5 py-2.5 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-white/30 hover:bg-white/15"
                 >
                   <span className="flex size-9 items-center justify-center rounded-2xl bg-white/15 shadow-lg shadow-black/10 backdrop-blur">
                     <Icon className="size-4 text-sky-200" />
                   </span>
-                  <span className="text-sm font-medium text-white/90">{label}</span>
+                  <span className="text-[0.85rem] font-medium text-white/90 sm:text-sm">{label}</span>
                 </div>
               ))}
             </div>
@@ -275,7 +273,7 @@ export default function Hero({ images, userName }: HeroProps) {
           <div className="size-6 rounded-full border-2 border-white/40 p-1">
             <div className="size-full animate-pulse rounded-full bg-white/60" />
           </div>
-          <span className="text-xs font-medium text-white/60">Role para explorar</span>
+          <span className="text-[0.7rem] font-medium text-white/60 sm:text-xs">Role para explorar</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- refresh the home hero with fluid spacing, softer typography, and animated background accents
- rework the destinations section styling with responsive typography, subtle gradients, and fade-in motion
- add reusable animation keyframes to globals for float and fade-up effects used across the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33b5112288333a0cd70e033d96b88