### PR TITLE
Reduce middleware edge function bundle size

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,13 +1,29 @@
-import { withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
-export default withAuth({
-  callbacks: {
-    authorized: ({ token }) => !!token,
-  },
-  pages: {
-    signIn: "/login",
-  },
-});
+const LOGIN_PATH = "/login";
+
+export async function middleware(request: NextRequest) {
+  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+
+  if (token) {
+    return NextResponse.next();
+  }
+
+  if (request.nextUrl.pathname.startsWith("/api/")) {
+    return new NextResponse(JSON.stringify({ message: "Unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = LOGIN_PATH;
+  loginUrl.searchParams.set("callbackUrl", request.nextUrl.pathname + request.nextUrl.search);
+
+  return NextResponse.redirect(loginUrl);
+}
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- replace the `withAuth` helper in the middleware with a custom handler built on `getToken`
- ensure unauthorized API requests receive a 401 JSON response and other routes redirect to the login page with a callback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33ca83c988333b0f81510dca947c2