### PR TITLE
Fix login page searchParams typing for Next 15

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,10 +4,12 @@ import { auth } from "@/lib/auth";
 
 import LoginPageClient from "./login-page-client";
 
+type LoginPageSearchParams = {
+  callbackUrl?: string | string[];
+};
+
 type LoginPageProps = {
-  searchParams?: {
-    callbackUrl?: string;
-  };
+  searchParams?: Promise<LoginPageSearchParams>;
 };
 
 const DEFAULT_AUTHENTICATED_DESTINATION = "/usuario";
@@ -29,10 +31,14 @@ function resolveRedirectDestination(
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const callbackParam = resolvedSearchParams?.callbackUrl;
+  const callbackUrl = Array.isArray(callbackParam) ? callbackParam[0] : callbackParam;
+
   const session = await auth();
 
   if (session?.user) {
-    const destination = resolveRedirectDestination(searchParams?.callbackUrl, session.user.role);
+    const destination = resolveRedirectDestination(callbackUrl, session.user.role);
     redirect(destination);
   }
 


### PR DESCRIPTION
## Summary
- update the login page props typing to await the new Promise-based searchParams API
- normalize the callbackUrl value before resolving the post-login redirect

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e340eeb0f083339d48acfb31432301