### PR TITLE
Revamp home page hero and layout for responsiveness

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import {
   type SerializedDestination,
 } from "@/lib/destinations";
 import { prisma } from "@/lib/prisma";
-import { MapPin, Hotel, Wand2, Headphones, Sparkles, ArrowRight, Star } from "lucide-react";
+import { Hotel, Wand2, Headphones, Sparkles, ArrowRight } from "lucide-react";
 
 export default async function HomePage() {
   const session = await auth();
@@ -142,127 +142,80 @@ export default async function HomePage() {
   if (!heroImages.length) {
     // Fallback (inalterado conceitualmente)
     heroImages.push(
-      
       "https://images.unsplash.com/photo-1516483638261-f4dbaf036963?q=80&w=1920&auto=format&fit=crop",
     );
   }
 
+  const featureCards = [
+    {
+      title: "Hospedagens selecionadas",
+      description: "Parcerias com hotéis e villas de alto padrão.",
+      icon: Hotel,
+    },
+    {
+      title: "Experiências exclusivas",
+      description: "Roteiros imersivos com toque local.",
+      icon: Wand2,
+    },
+    {
+      title: "Suporte 24/7",
+      description: "Acompanhamento antes, durante e depois da viagem.",
+      icon: Headphones,
+    },
+  ];
+
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      {/* HERO premium com carrossel (sem alterar props) */}
+    <main className="flex min-h-dvh flex-col bg-background text-foreground">
       <Hero images={heroImages} userName={session?.user?.name ?? null} />
 
-      {/* Seção de destinos com estética alinhada à página /destinos */}
-      <section
-        id="destinos"
-        className="relative mx-auto -mt-10 w-full max-w-6xl px-4 pb-16 pt-6 sm:px-6 md:-mt-12 md:pt-10 lg:max-w-7xl lg:px-8"
-      >
-        <div className="pointer-events-none absolute inset-x-6 -top-10 -z-10 hidden h-[420px] rounded-[2.5rem] bg-gradient-to-br from-blue-400/15 via-transparent to-purple-400/15 blur-3xl sm:block" />
+      <section className="bg-background">
+        <div className="mx-auto w-full max-w-6xl px-6 py-16 sm:px-8 lg:px-12">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="max-w-2xl space-y-3">
+              <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
+                <Sparkles className="size-4" /> Destinos recentes
+              </span>
+              <h2 className="text-balance text-2xl font-semibold leading-tight sm:text-3xl">
+                Descobertas selecionadas para a sua próxima viagem
+              </h2>
+              <p className="text-sm text-muted-foreground sm:text-base">
+                Uma curadoria atualizada com os lugares que conquistaram nossos viajantes nas últimas semanas.
+              </p>
+            </div>
 
-        <div className="group relative overflow-hidden rounded-[2.25rem] border border-white/15 bg-gradient-to-br from-white/80 via-white/65 to-white/55 p-5 shadow-2xl shadow-black/5 backdrop-blur-xl transition-all duration-500 hover:shadow-3xl dark:from-white/[0.07] dark:via-white/[0.05] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
-          <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-transparent to-purple-500/10" />
+            <Link
+              href="/destinos"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              aria-label="Ver todos os destinos"
+            >
+              Ver todos
+              <ArrowRight className="size-4" />
+            </Link>
           </div>
 
-          <div className="pointer-events-none absolute -left-20 top-12 size-44 rounded-full bg-blue-500/10 blur-3xl sm:-left-12 sm:top-10 sm:size-60" />
-          <div className="pointer-events-none absolute -right-16 bottom-12 size-48 rounded-full bg-purple-500/15 blur-3xl sm:-right-12 sm:bottom-16 sm:size-60" />
-
-          <div className="relative">
-            <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between md:gap-6">
-              <div className="flex-1 space-y-3">
-                <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-gradient-to-r from-primary/15 via-primary/10 to-primary/5 px-3 py-1 text-[0.7rem] font-semibold text-primary shadow-sm shadow-primary/10 backdrop-blur-sm transition-all duration-300 hover:scale-[1.03] hover:shadow-md sm:px-3.5 sm:py-1.5 sm:text-xs">
-                  <Sparkles className="size-3 animate-pulse sm:size-3.5" />
-                  <span>Seleção Evastur</span>
-                  <Star className="size-3 fill-primary text-primary" />
-                </div>
-
-                <h2 className="text-balance text-[clamp(1.7rem,4vw,2.6rem)] font-semibold tracking-tight text-foreground sm:font-bold">
-                  Destinos que contam
-                  <span className="ml-2 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-purple-400">
-                    histórias
-                  </span>
-                </h2>
-
-                <p className="max-w-prose text-pretty text-[0.9rem] leading-relaxed text-muted-foreground sm:text-[0.95rem] md:text-base">
-                  Curadoria fina, charme local e experiências que você só descobre com quem entende do assunto.
-                </p>
-              </div>
-
-              <Link
-                href="/destinos"
-                className="group/btn relative inline-flex items-center gap-2 self-start overflow-hidden rounded-full border border-primary/10 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent px-4 py-2 text-[0.85rem] font-semibold text-primary backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:from-primary/20 hover:via-primary/10 hover:to-primary/5 hover:text-primary sm:px-5 sm:py-2.5 sm:text-sm"
-                aria-label="Ver todos os destinos"
-              >
-                <span className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/25 to-transparent opacity-0 transition-opacity duration-300 group-hover/btn:opacity-100" />
-                <MapPin className="size-4 transition-all duration-300 group-hover/btn:-translate-y-0.5 group-hover/btn:text-primary" />
-                <span>Ver todos</span>
-                <ArrowRight className="size-4 transition-all duration-300 group-hover/btn:translate-x-1" />
-              </Link>
-            </div>
-
-            <div className="mt-6 sm:mt-8 md:mt-9">
-              <div className="motion-safe:animate-[fade-up_0.9s_ease-out_forwards] motion-safe:opacity-0">
-                <DestinationGrid
-                  destinations={destinations}
-                  canFavorite={Boolean(session?.user?.id)}
-                />
-              </div>
-            </div>
+          <div className="mt-10">
+            <DestinationGrid
+              destinations={destinations}
+              canFavorite={Boolean(session?.user?.id)}
+            />
           </div>
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-4 pb-16 sm:px-6 sm:pb-20 lg:max-w-7xl lg:px-8 lg:pb-24">
-        <div className="relative overflow-hidden rounded-[2.25rem] border border-white/15 bg-gradient-to-br from-white/80 via-white/65 to-white/55 p-5 backdrop-blur-xl dark:from-white/[0.07] dark:via-white/[0.05] dark:to-white/[0.03] sm:p-6 md:p-8 lg:p-10">
-          <div className="pointer-events-none absolute inset-0 opacity-30">
-            <div className="absolute -top-20 left-14 size-60 rounded-full bg-blue-500/10 blur-3xl" />
-            <div className="absolute bottom-0 right-0 size-64 rounded-full bg-purple-500/10 blur-3xl" />
-          </div>
-
-          <div className="relative grid gap-4 sm:gap-5 md:grid-cols-3 md:gap-6">
-            {[
-              {
-                title: "Hospedagens selecionadas",
-                desc: "Parcerias com hotéis e villas de alto padrão.",
-                Icon: Hotel,
-                color: "from-blue-500/20 to-blue-600/10 text-blue-500 dark:text-blue-400",
-              },
-              {
-                title: "Experiências exclusivas",
-                desc: "Roteiros imersivos com toque local.",
-                Icon: Wand2,
-                color: "from-purple-500/20 to-purple-600/10 text-purple-500 dark:text-purple-400",
-              },
-              {
-                title: "Suporte 24/7",
-                desc: "Antes, durante e depois da viagem.",
-                Icon: Headphones,
-                color: "from-emerald-500/20 to-emerald-600/10 text-emerald-500 dark:text-emerald-400",
-              },
-            ].map(({ title, desc, Icon, color }, i) => (
-              <div
-                key={i}
-                className="group/card relative overflow-hidden rounded-2xl border border-white/15 bg-gradient-to-br from-white/70 to-white/45 p-5 backdrop-blur-sm transition-all duration-500 hover:-translate-y-2 hover:border-white/40 hover:shadow-2xl dark:from-white/[0.05] dark:to-white/[0.02] sm:p-6"
-                style={{ animationDelay: `${i * 0.15}s` }}
+      <section className="border-t border-border bg-muted/20 py-16">
+        <div className="mx-auto w-full max-w-6xl px-6 sm:px-8 lg:px-12">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {featureCards.map(({ title, description, icon: Icon }) => (
+              <article
+                key={title}
+                className="flex h-full flex-col gap-3 rounded-2xl border border-border bg-background/60 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
               >
-                <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover/card:opacity-100">
-                  <div className={`absolute inset-0 bg-gradient-to-br ${color}`} />
-                </div>
-
-                <div className="relative flex flex-col gap-4 sm:flex-row sm:items-start">
-                  <div className={`relative grid size-14 shrink-0 place-items-center overflow-hidden rounded-2xl border border-white/20 bg-gradient-to-br shadow-lg transition-all duration-500 motion-safe:animate-[fade-up_0.9s_ease-out_forwards] motion-safe:opacity-0 group-hover/card:scale-110 group-hover/card:shadow-xl sm:size-16 ${color}`}>
-                    <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/20 to-transparent" />
-                    <Icon className="relative z-10 size-6 transition-transform duration-500 group-hover/card:rotate-12 sm:size-7" />
-                  </div>
-
-                  <div className="flex-1">
-                    <h3 className="text-[0.95rem] font-semibold leading-tight text-foreground sm:text-base">{title}</h3>
-                    <p className="mt-2 text-[0.85rem] leading-relaxed text-muted-foreground sm:text-[0.95rem]">{desc}</p>
-                  </div>
-                </div>
-
-                <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-white/35 to-transparent opacity-0 transition-opacity duration-500 group-hover/card:opacity-100" />
-              </div>
+                <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <Icon className="size-5" />
+                </span>
+                <h3 className="text-base font-semibold text-foreground">{title}</h3>
+                <p className="text-sm text-muted-foreground">{description}</p>
+              </article>
             ))}
           </div>
         </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,279 +1,151 @@
 "use client";
 
-import { useEffect, useMemo, useState, useRef, useCallback } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
-  Plane,
-  MapPin,
-  Sparkles,
-  Compass,
-  CalendarCheck2,
-  Ticket,
   ArrowRight,
-  Zap,
-  Shield,
-  Hotel,
-  Headphones,
+  CalendarCheck2,
+  Compass,
+  Plane,
+  Sparkles,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+
 import { QuoteForm } from "./home/quote-form";
 
-type HeroProps = {
+export type HeroProps = {
   images: string[];
   userName?: string | null;
 };
 
-const featureHighlights = [
-  { icon: Ticket, label: "Tarifas negociadas" },
-  { icon: Hotel, label: "Hotéis selecionados" },
-  { icon: MapPin, label: "Curadoria local autêntica" },
-  { icon: Headphones, label: "Suporte dedicado 24/7" },
-  { icon: Zap, label: "Experiências imersivas" },
-  { icon: Shield, label: "Atendimento seguro" },
+const FALLBACK_IMAGES = [
+  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1920&auto=format&fit=crop",
+  "https://images.unsplash.com/photo-1473893604213-3df9c15611d4?q=80&w=1920&auto=format&fit=crop",
+  "https://images.unsplash.com/photo-1516483638261-f4dbaf036963?q=80&w=1920&auto=format&fit=crop",
 ];
 
 export default function Hero({ images, userName }: HeroProps) {
-  const slides = useMemo(() => (images?.length ? images.slice(0, 6) : []), [images]);
+  const slides = useMemo(() => {
+    const normalized = Array.isArray(images)
+      ? images.filter((item) => typeof item === "string" && item.trim().length)
+      : [];
+
+    if (!normalized.length) {
+      return FALLBACK_IMAGES;
+    }
+
+    return normalized.slice(0, 5);
+  }, [images]);
+
   const [active, setActive] = useState(0);
-  const [paused, setPaused] = useState(false);
-  const containerRef = useRef<HTMLElement>(null);
-  const slideCount = slides.length;
-
-  const normalizeIndex = useCallback(
-    (index: number) => {
-      if (!slideCount) return 0;
-      const remainder = index % slideCount;
-      return remainder >= 0 ? remainder : remainder + slideCount;
-    },
-    [slideCount],
-  );
-
-  const goToSlide = useCallback(
-    (next: number | ((prev: number) => number)) => {
-      if (!slideCount) return;
-      setActive((prev) => {
-        const target = typeof next === "function" ? next(prev) : next;
-        const normalized = normalizeIndex(target);
-        return normalized === prev ? prev : normalized;
-      });
-    },
-    [normalizeIndex, slideCount],
-  );
 
   useEffect(() => {
-    if (!slideCount) {
+    if (slides.length <= 1) return;
+
+    const id = window.setInterval(() => {
+      setActive((prev) => (prev + 1) % slides.length);
+    }, 7000);
+
+    return () => window.clearInterval(id);
+  }, [slides.length]);
+
+  useEffect(() => {
+    if (!slides.length) {
       setActive(0);
       return;
     }
-    setActive((prev) => {
-      if (!Number.isFinite(prev) || prev < 0 || prev >= slideCount) {
-        return 0;
-      }
-      return prev;
-    });
-  }, [slideCount]);
 
-  // Auto-rotate (mantido), com pausa por foco/hover e respeito a prefers-reduced-motion
-  useEffect(() => {
-    if (!slideCount) return;
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
-    if (media.matches || paused) return;
-
-    const t = setInterval(() => {
-      setActive((prev) => normalizeIndex(prev + 1));
-    }, 5500);
-    return () => clearInterval(t);
-  }, [slideCount, paused, normalizeIndex]);
-
-  // Acessibilidade: setas do teclado (←/→) para navegar
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(document.activeElement)) return;
-      if (slideCount <= 1) return;
-      if (e.key === "ArrowRight") goToSlide((p) => p + 1);
-      if (e.key === "ArrowLeft") goToSlide((p) => p - 1);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [goToSlide, slideCount]);
+    if (active >= slides.length) {
+      setActive(0);
+    }
+  }, [slides, active]);
 
   return (
-    <section
-      ref={containerRef}
-      className="relative isolate min-h-[78dvh] overflow-clip rounded-b-[2.25rem] border-b border-white/10 bg-black/70 sm:min-h-[82dvh] md:min-h-[86dvh] md:rounded-b-[3rem]"
-      aria-label="Destaques Evastur"
-      tabIndex={0}
-      onMouseEnter={() => setPaused(true)}
-      onMouseLeave={() => setPaused(false)}
-      onFocus={() => setPaused(true)}
-      onBlur={() => setPaused(false)}
-    >
-      {/* Slides em camadas com transição suave */}
-      <div className="absolute inset-0 -z-10">
+    <section className="relative isolate flex min-h-[70vh] w-full flex-col justify-center overflow-hidden bg-slate-950 text-white">
+      <div className="absolute inset-0">
         {slides.map((src, idx) => (
-          <div
+          <Image
             key={`${src}-${idx}`}
-            className={cn(
-              "absolute inset-0 transition-all duration-[2000ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform",
-              active === idx ? "scale-100 opacity-100" : "scale-105 opacity-0",
-            )}
-            aria-hidden={active !== idx}
-          >
-            <Image
-              src={src}
-              alt="Paisagem de destino"
-              fill
-              priority={idx === 0}
-              className="object-cover"
-              quality={90}
-              sizes="100vw"
-            />
-            {/* Máscaras para legibilidade */}
-            <div className="absolute inset-0 bg-gradient-to-b from-black/55 via-black/45 to-black/80" />
-            <div className="absolute inset-0 bg-gradient-to-r from-black/30 via-transparent to-black/25" />
-
-            {/* Brilhos decorativos */}
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(59,130,246,0.16),transparent_50%)] mix-blend-overlay" />
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_70%_80%,rgba(168,85,247,0.12),transparent_50%)] mix-blend-overlay" />
-          </div>
+            src={src}
+            alt="Paisagem de destino"
+            fill
+            priority={idx === 0}
+            className={`absolute inset-0 object-cover transition-opacity duration-1000 ${active === idx ? "opacity-100" : "opacity-0"}`}
+            sizes="100vw"
+          />
         ))}
+        <div className="absolute inset-0 bg-slate-950/70" />
+        <div className="absolute inset-0 bg-gradient-to-b from-slate-950/90 via-slate-950/60 to-slate-950/90" />
       </div>
 
-      {/* Partículas/blur blobs sutis (respeitam reduced-motion implicitamente) */}
-      <div className="pointer-events-none absolute inset-0 -z-10 opacity-45">
-        <div className="absolute left-[12%] top-[18%] size-72 animate-float-slow rounded-full bg-blue-500/25 blur-3xl" />
-        <div className="absolute bottom-[12%] right-[10%] size-64 animate-float-delayed rounded-full bg-purple-500/20 blur-3xl" />
-        <div className="absolute left-[48%] top-[58%] size-40 animate-float-slower rounded-full bg-emerald-400/15 blur-3xl" />
-      </div>
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-16 sm:px-10 sm:py-20 lg:flex-row lg:items-center lg:gap-12 lg:py-24">
+        <div className="flex-1 space-y-6">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/80 backdrop-blur">
+            <Sparkles className="size-4" /> Experiências Evastur
+          </span>
 
+          <div className="space-y-4">
+            <h1 className="text-balance text-3xl font-semibold leading-tight sm:text-4xl lg:text-5xl">
+              {userName ? (
+                <>
+                  {userName.split(" ")[0]}, planeje sua próxima viagem com conforto e autenticidade.
+                </>
+              ) : (
+                <>Viagens sob medida para criar memórias que duram para sempre.</>
+              )}
+            </h1>
+            <p className="max-w-xl text-pretty text-sm leading-relaxed text-white/80 sm:text-base">
+              Curadoria humana, atendimento próximo e destinos que combinam com o seu momento. Nós cuidamos de tudo enquanto você aproveita cada detalhe.
+            </p>
+          </div>
 
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+            <Link
+              href="/destinos"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              <Plane className="size-4" />
+              Explorar destinos
+              <ArrowRight className="size-4" />
+            </Link>
+            <Link
+              href="/sobre-nos"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              <Compass className="size-4" />
+              Conheça a Evastur
+            </Link>
+            <Link
+              href="/contato"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              <CalendarCheck2 className="size-4" />
+              Falar com especialista
+            </Link>
+          </div>
 
-      {/* Conteúdo principal */}
-      <div className="mx-auto w-full max-w-6xl px-4 py-14 sm:px-6 sm:py-[4.5rem] md:max-w-7xl md:py-20 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_500px] lg:items-start xl:grid-cols-[minmax(0,1fr)_560px] 2xl:grid-cols-[minmax(0,1fr)_600px]">
-          <div className="flex flex-col gap-6 sm:gap-8 lg:pr-8 xl:pr-12">
-            {/* Badge */}
-            <div className="group inline-flex w-fit animate-[fadeIn_1s_ease-out] items-center gap-2.5 rounded-full border border-white/25 bg-white/15 px-3.5 py-1.5 text-[0.75rem] font-medium text-white shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:border-white/40 hover:bg-white/20 sm:px-4 sm:py-2 sm:text-sm">
-              <Sparkles className="size-3.5 animate-pulse text-yellow-300 sm:size-4" />
-              <span>Agência boutique • experiências sob medida</span>
-              <span className="size-1.5 animate-pulse rounded-full bg-green-400 shadow-[0_0_8px_theme(colors.green.400)]" />
-            </div>
-
-            {/* Headline */}
-            <div className="max-w-3xl animate-[fadeIn_1.2s_ease-out] space-y-4">
-              <h1 className="text-balance text-[clamp(2rem,5vw,3.25rem)] font-semibold leading-[1.1] tracking-tight text-white drop-shadow-2xl sm:font-bold md:text-[clamp(2.4rem,4vw,3.6rem)]">
-                Descubra o mundo com a{" "}
-                <span className="relative inline-block">
-                  <span className="relative z-10 bg-gradient-to-r from-blue-400 via-blue-300 to-purple-400 bg-clip-text text-transparent">
-                    Evastur
-                  </span>
-                  <span
-                    aria-hidden
-                    className="absolute inset-0 bg-gradient-to-r from-blue-400 via-blue-300 to-purple-400 opacity-50 blur-xl"
-                  />
-                </span>
-                : viagens premium, memórias eternas.
-              </h1>
-
-              <p className="max-w-xl text-pretty text-[0.95rem] leading-relaxed text-white/85 drop-shadow-lg sm:text-[1.05rem] md:text-[1.15rem] md:leading-relaxed">
-                {userName ? (
-                  <>
-                    <span className="font-semibold text-white">{userName.split(" ")[0]}</span>, planejamos sua próxima jornada com
-                    curadoria, conforto e autenticidade — do primeiro clique ao último pôr do sol.
-                  </>
-                ) : (
-                  <>Do primeiro clique ao último pôr do sol: roteiros exclusivos, hotéis selecionados a dedo e suporte 24/7.</>
-                )}
-              </p>
-            </div>
-
-            {/* CTAs */}
-            <div className="flex animate-[fadeIn_1.4s_ease-out] flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-              <Link
-                href="/destinos"
-                className={cn(
-                  "group relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-full border border-white/30 bg-gradient-to-r from-blue-500/90 to-purple-500/90 px-5 py-3 text-sm font-semibold text-white shadow-xl backdrop-blur transition-all duration-300",
-                  "hover:-translate-y-1 hover:shadow-2xl hover:shadow-blue-500/50 sm:px-6 sm:py-3 sm:text-[0.95rem]",
-                )}
-              >
-                <span className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-                <Plane className="relative z-10 size-4 transition-transform duration-300 group-hover:translate-x-0.5 sm:size-5" />
-                <span className="relative z-10">Explorar destinos</span>
-                <ArrowRight className="relative z-10 size-4 transition-transform duration-300 group-hover:translate-x-1 sm:size-5" />
-              </Link>
-
-              <Link
-                href="/sobre-nos"
-                className="group inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2.5 text-[0.85rem] font-medium text-white/95 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-white/40 hover:bg-white/20 hover:shadow-lg sm:px-5 sm:py-3 sm:text-[0.95rem]"
-              >
-                <Compass className="size-4 transition-transform duration-300 group-hover:rotate-12 sm:size-5" />
-                <span>Conheça a Evastur</span>
-              </Link>
-
-              <Link
-                href="/contato"
-                className="group inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/40 bg-gradient-to-r from-emerald-500/20 to-emerald-400/20 px-4 py-2.5 text-[0.85rem] font-medium text-emerald-50 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:border-emerald-400/60 hover:from-emerald-500/30 hover:to-emerald-400/30 hover:shadow-lg hover:shadow-emerald-500/30 sm:px-5 sm:py-3 sm:text-[0.95rem]"
-              >
-                <CalendarCheck2 className="size-4 transition-transform duration-300 group-hover:scale-110 sm:size-5" />
-                <span>Montar roteiro</span>
-              </Link>
-            </div>
-
-            {/* Benefícios */}
-            <div className="mt-6 grid animate-[fadeIn_1.6s_ease-out] gap-3 text-white/85 sm:grid-cols-2 lg:grid-cols-3">
-              {featureHighlights.map(({ icon: Icon, label }) => (
-                <div
-                  key={label}
-                  className="group flex items-center gap-3 rounded-2xl border border-white/15 bg-white/10 px-3.5 py-2.5 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-white/30 hover:bg-white/15"
-                >
-                  <span className="flex size-9 items-center justify-center rounded-2xl bg-white/15 shadow-lg shadow-black/10 backdrop-blur">
-                    <Icon className="size-4 text-sky-200" />
-                  </span>
-                  <span className="text-[0.85rem] font-medium text-white/90 sm:text-sm">{label}</span>
-                </div>
+          {slides.length > 1 && (
+            <div className="flex items-center gap-2 pt-2">
+              {slides.map((_, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => setActive(index)}
+                  className={`h-1.5 rounded-full transition-all ${
+                    active === index
+                      ? "w-10 bg-white"
+                      : "w-5 bg-white/40 hover:w-7 hover:bg-white/70"
+                  }`}
+                  aria-label={`Ver imagem ${index + 1}`}
+                  aria-pressed={active === index}
+                />
               ))}
             </div>
-          </div>
-
-          <div className="flex items-stretch lg:pl-4 xl:pl-8">
-            <QuoteForm />
-          </div>
+          )}
         </div>
-      </div>
 
-        {/* Indicadores do carrossel */}
-        {slideCount > 1 && (
-          <div className="mt-2 flex animate-[fadeIn_1.8s_ease-out] items-center gap-2.5 sm:mt-4" role="tablist" aria-label="Seleção de slides">
-            {slides.map((_, i) => (
-              <button
-                key={i}
-                role="tab"
-                aria-selected={active === i}
-                aria-controls={`hero-slide-${i}`}
-                aria-label={`Ir para o slide ${i + 1}`}
-                onClick={() => goToSlide(i)}
-                className={cn(
-                  "group relative h-1.5 rounded-full transition-all duration-500",
-                  active === i
-                    ? "w-10 bg-gradient-to-r from-blue-400 to-purple-400 shadow-lg shadow-blue-500/50"
-                    : "w-6 bg-white/40 hover:w-8 hover:bg-white/60",
-                )}
-              >
-                {active === i && <span className="absolute inset-0 animate-pulse rounded-full bg-white/30" />}
-              </button>
-            ))}
-          </div>
-        )}
-
-      {/* Indicador de scroll */}
-      <div className="absolute bottom-8 left-1/2 hidden -translate-x-1/2 animate-bounce md:block">
-        <div className="flex flex-col items-center gap-2">
-          <div className="size-6 rounded-full border-2 border-white/40 p-1">
-            <div className="size-full animate-pulse rounded-full bg-white/60" />
-          </div>
-          <span className="text-[0.7rem] font-medium text-white/60 sm:text-xs">Role para explorar</span>
+        <div className="w-full max-w-xl lg:max-w-md">
+          <QuoteForm />
         </div>
       </div>
     </section>

--- a/components/home/quote-form.tsx
+++ b/components/home/quote-form.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
   useState,
 } from "react";
-import { AnimatePresence, motion } from "framer-motion";
 import {
   CalendarDays,
   MapPin,
@@ -18,14 +17,6 @@ import {
 } from "lucide-react";
 
 const WHATSAPP_NUMBER = "5568992552607";
-
-const baseFieldClasses =
-  "flex w-full items-center gap-3 rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white shadow-[0_18px_45px_-24px_rgba(15,23,42,0.65)] backdrop-blur transition focus-within:border-white/40 focus-within:bg-white/15 focus-within:shadow-[0_24px_55px_-30px_rgba(14,165,233,0.65)] sm:text-base";
-
-const inputClasses =
-  "h-11 w-full bg-transparent text-white placeholder:text-white/60 focus:outline-none";
-
-const labelClasses = "text-xs font-medium uppercase tracking-wide text-white/70";
 
 const initialFormState = {
   name: "",
@@ -43,41 +34,28 @@ type FormKey = keyof FormState;
 
 type FormErrors = Partial<Record<FormKey, string>>;
 
-const formMotion = {
-  initial: { opacity: 0, y: 28 },
-  animate: { opacity: 1, y: 0 },
-};
-
-const fieldMotion = {
-  initial: { opacity: 0, y: 16 },
-  animate: { opacity: 1, y: 0 },
-};
-
-const errorMotion = {
-  initial: { opacity: 0, y: -4 },
-  animate: { opacity: 1, y: 0 },
-  exit: { opacity: 0, y: -4 },
-};
+type FormStatus =
+  | {
+      type: "error" | "success";
+      message: string;
+    }
+  | null;
 
 export function QuoteForm() {
   const [form, setForm] = useState<FormState>(initialFormState);
   const [errors, setErrors] = useState<FormErrors>({});
-  const [status, setStatus] = useState<
-    | {
-        type: "error" | "success";
-        message: string;
-      }
-    | null
-  >(null);
+  const [status, setStatus] = useState<FormStatus>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const peopleOptions = useMemo(() => {
-    return Array.from({ length: 10 }, (_, index) => `${index + 1}`);
-  }, []);
+  const peopleOptions = useMemo(
+    () => Array.from({ length: 10 }, (_, index) => `${index + 1}`),
+    [],
+  );
 
   const handleChange = (field: FormKey) =>
     (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
       const { value } = event.target;
+
       setForm((prev) => ({ ...prev, [field]: value }));
       setErrors((prev) => ({ ...prev, [field]: undefined }));
       setStatus(null);
@@ -127,8 +105,6 @@ export function QuoteForm() {
       return;
     }
 
-    setErrors({});
-
     const message = buildMessage();
     const encoded = encodeURIComponent(message);
     const redirectUrl = `https://wa.me/${WHATSAPP_NUMBER}?text=${encoded}`;
@@ -142,36 +118,30 @@ export function QuoteForm() {
       type: "success",
       message: "Perfeito! Abrimos seu WhatsApp com os detalhes do pedido.",
     });
+
     setIsSubmitting(false);
     setForm(initialFormState);
   };
 
   return (
-    <motion.form
-      {...formMotion}
-      transition={{ duration: 0.6, ease: "easeOut" }}
+    <form
       onSubmit={handleSubmit}
-      className="relative w-full overflow-hidden rounded-3xl border border-white/20 bg-white/15 p-6 shadow-[0_35px_120px_-45px_rgba(15,23,42,0.9)] backdrop-blur-xl sm:p-7 md:p-8"
+      className="flex w-full flex-col gap-6 rounded-3xl bg-white/90 p-6 text-slate-900 shadow-xl ring-1 ring-white/60 backdrop-blur-sm dark:bg-slate-900/90 dark:text-slate-100 dark:ring-white/10 sm:p-8"
     >
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-blue-500/10 to-purple-500/10" />
-      <div className="pointer-events-none absolute -left-10 top-24 size-36 rounded-full bg-blue-400/20 blur-3xl" />
-      <div className="pointer-events-none absolute -right-16 bottom-14 size-44 rounded-full bg-purple-400/15 blur-[120px]" />
-
-      <div className="relative flex flex-col gap-2 pb-6 text-white">
-        <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white/80 backdrop-blur">
-          <Send className="size-3.5" /> Solicite agora
+      <div className="space-y-1">
+        <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+          <Send className="size-4" /> Solicite agora
         </span>
-        <h2 className="text-2xl font-semibold leading-tight sm:text-3xl">Monte seu orçamento personalizado</h2>
-        <p className="text-sm text-white/80 sm:text-base">
-          Informe os detalhes da sua viagem e nossa equipe retorna com as melhores opções.
+        <h2 className="text-xl font-semibold sm:text-2xl">Monte seu orçamento</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Informe os detalhes da viagem e nossa equipe retorna com sugestões personalizadas.
         </p>
       </div>
 
-      <div className="relative grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-2">
         <Field
-          icon={<User className="size-4 text-white/70" />}
-          label="Nome da pessoa"
-          motionIndex={0}
+          icon={<User className="size-4" />}
+          label="Nome completo"
           error={errors.name}
         >
           <input
@@ -181,15 +151,14 @@ export function QuoteForm() {
             onChange={handleChange("name")}
             placeholder="Como devemos te chamar?"
             autoComplete="name"
-            className={inputClasses}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="text"
           />
         </Field>
 
         <Field
-          icon={<Phone className="size-4 text-white/70" />}
+          icon={<Phone className="size-4" />}
           label="Número de celular"
-          motionIndex={1}
           error={errors.phone}
         >
           <input
@@ -199,15 +168,14 @@ export function QuoteForm() {
             onChange={handleChange("phone")}
             placeholder="(68) 99255-2607"
             autoComplete="tel"
-            className={inputClasses}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="tel"
           />
         </Field>
 
         <Field
-          icon={<MapPin className="size-4 text-white/70" />}
-          label="De onde"
-          motionIndex={2}
+          icon={<MapPin className="size-4" />}
+          label="Cidade de origem"
           error={errors.origin}
         >
           <input
@@ -217,15 +185,14 @@ export function QuoteForm() {
             onChange={handleChange("origin")}
             placeholder="Cidade de saída"
             autoComplete="address-level2"
-            className={inputClasses}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="text"
           />
         </Field>
 
         <Field
-          icon={<MapPin className="size-4 text-white/70" />}
-          label="Para onde"
-          motionIndex={3}
+          icon={<MapPin className="size-4" />}
+          label="Destino"
           error={errors.destination}
         >
           <input
@@ -233,16 +200,15 @@ export function QuoteForm() {
             name="destination"
             value={form.destination}
             onChange={handleChange("destination")}
-            placeholder="Destino dos sonhos"
-            className={inputClasses}
+            placeholder="Para onde deseja ir?"
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="text"
           />
         </Field>
 
         <Field
-          icon={<CalendarDays className="size-4 text-white/70" />}
+          icon={<CalendarDays className="size-4" />}
           label="Data de ida"
-          motionIndex={4}
           error={errors.departureDate}
         >
           <input
@@ -250,15 +216,14 @@ export function QuoteForm() {
             name="departureDate"
             value={form.departureDate}
             onChange={handleChange("departureDate")}
-            className={inputClasses}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="date"
           />
         </Field>
 
         <Field
-          icon={<CalendarDays className="size-4 text-white/70" />}
+          icon={<CalendarDays className="size-4" />}
           label="Data de volta"
-          motionIndex={5}
           error={errors.returnDate}
         >
           <input
@@ -266,16 +231,15 @@ export function QuoteForm() {
             name="returnDate"
             value={form.returnDate}
             onChange={handleChange("returnDate")}
-            className={inputClasses}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
             type="date"
             min={form.departureDate || undefined}
           />
         </Field>
 
         <Field
-          icon={<Users className="size-4 text-white/70" />}
+          icon={<Users className="size-4" />}
           label="Quantidade de pessoas"
-          motionIndex={6}
           error={errors.people}
         >
           <select
@@ -283,7 +247,7 @@ export function QuoteForm() {
             name="people"
             value={form.people}
             onChange={handleChange("people")}
-            className={`${inputClasses} pr-8`}
+            className="h-11 w-full rounded-xl border border-slate-200 bg-white/80 px-3 text-sm font-medium text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/30"
           >
             <option value="" disabled>
               Selecionar
@@ -297,33 +261,25 @@ export function QuoteForm() {
         </Field>
       </div>
 
-      <motion.button
+      <button
         type="submit"
-        className="group relative mt-6 inline-flex w-full items-center justify-center gap-2 overflow-hidden rounded-2xl bg-gradient-to-r from-blue-500 via-sky-500 to-purple-500 px-6 py-3 text-base font-semibold text-white shadow-lg transition focus:outline-none focus:ring-2 focus:ring-sky-200/80 focus:ring-offset-2 focus:ring-offset-slate-900"
-        whileHover={{ scale: 1.01 }}
-        whileTap={{ scale: 0.99 }}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
         disabled={isSubmitting}
       >
-        <span className="absolute inset-0 bg-white/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
         <Send className="size-4" />
-        {isSubmitting ? "Enviando..." : "Enviar"}
-      </motion.button>
+        {isSubmitting ? "Enviando..." : "Enviar para o WhatsApp"}
+      </button>
 
-      <AnimatePresence>
-        {status && (
-          <motion.p
-            key={status.message}
-            {...errorMotion}
-            transition={{ duration: 0.25 }}
-            className={`mt-4 text-center text-sm font-medium ${
-              status.type === "success" ? "text-emerald-100" : "text-red-200"
-            }`}
-          >
-            {status.message}
-          </motion.p>
-        )}
-      </AnimatePresence>
-    </motion.form>
+      {status && (
+        <p
+          className={`text-sm font-medium ${
+            status.type === "success" ? "text-emerald-600 dark:text-emerald-300" : "text-red-600 dark:text-rose-300"
+          }`}
+        >
+          {status.message}
+        </p>
+      )}
+    </form>
   );
 }
 
@@ -331,35 +287,20 @@ type FieldProps = {
   children: ReactNode;
   icon: ReactNode;
   label: string;
-  motionIndex: number;
   error?: string;
 };
 
-function Field({ children, icon, label, motionIndex, error }: FieldProps) {
+function Field({ children, icon, label, error }: FieldProps) {
   return (
-    <motion.div
-      {...fieldMotion}
-      transition={{ duration: 0.45, delay: 0.05 * motionIndex, ease: "easeOut" }}
-      className="flex flex-col gap-2"
-    >
-      <label className={labelClasses}>{label}</label>
-      <div className={`${baseFieldClasses} ${error ? "border-red-300/70 bg-red-500/10" : ""}`}>
-        <span className="shrink-0">
-          {icon}
-        </span>
+    <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+      <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+        {icon}
+        {label}
+      </span>
+      <div className={`flex w-full flex-col gap-1 ${error ? "text-red-600 dark:text-rose-300" : "text-slate-700 dark:text-slate-100"}`}>
         {children}
+        {error && <span className="text-xs font-medium">{error}</span>}
       </div>
-      <AnimatePresence>
-        {error && (
-          <motion.span
-            {...errorMotion}
-            transition={{ duration: 0.25 }}
-            className="text-xs font-medium text-red-200"
-          >
-            {error}
-          </motion.span>
-        )}
-      </AnimatePresence>
-    </motion.div>
+    </label>
   );
 }


### PR DESCRIPTION
## Summary
- replace the home hero with a lighter, responsive banner that rotates images smoothly and surfaces key CTAs
- simplify the quote form styling and interactions to remove heavy motion effects while keeping validation and WhatsApp handoff
- refresh the destinations and highlights sections to use cleaner responsive layouts that match the streamlined design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e34ae541f483338c65f42fbcf385c1