### PR TITLE
Fix mobile panel animation transition types

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -21,7 +21,7 @@ import {
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, cubicBezier, easeInOut, motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
@@ -56,11 +56,15 @@ const NAV_ANIMATION = {
 };
 
 const MOBILE_PANEL_VARIANTS = {
-  hidden: { opacity: 0, height: 0, transition: { duration: 0.25, ease: "easeInOut" } },
+  hidden: {
+    opacity: 0,
+    height: 0,
+    transition: { duration: 0.25, ease: easeInOut },
+  },
   visible: {
     opacity: 1,
     height: "auto",
-    transition: { duration: 0.4, ease: [0.21, 0.47, 0.32, 0.98] },
+    transition: { duration: 0.4, ease: cubicBezier(0.21, 0.47, 0.32, 0.98) },
   },
 };
 


### PR DESCRIPTION
## Summary
- import easing helpers from framer-motion for the mobile navigation panel variants
- replace string/array ease definitions with easing functions that satisfy the updated Framer Motion types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54a5ace04833391cb386a94161767